### PR TITLE
Make heavy dependencies optional extras

### DIFF
--- a/README.md
+++ b/README.md
@@ -58,6 +58,15 @@ $ cd vizseq
 $ pip install -e .
 ```
 
+The base install keeps dependencies lightweight. Install optional extras only if
+you need them:
+```bash
+$ pip install vizseq[embeddings]  # LASER and BERTScore scorers (pulls in torch)
+$ pip install vizseq[audio]       # reading .wav/.flac/.sph audio sources
+$ pip install vizseq[translate]   # Google Translate integration
+$ pip install vizseq[all]         # everything above
+```
+
 ### [Documentation](https://facebookresearch.github.io/vizseq)
 
 ### Jupyter Notebook Examples

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -22,20 +22,31 @@ classifiers = [
 dependencies = [
     "numpy>=1.20.0,<3.0.0",
     "sacrebleu>=1.4.13,<3.0.0",
-    "torch>=1.9.0,<3.0.0",
     "tqdm>=4.0.0,<5.0.0",
     "nltk>=3.5,<4.0.0",
     "py-rouge>=1.1,<2.0.0",
     "langid>=1.1.6,<2.0.0",
-    "google-cloud-translate>=3.0.0,<4.0.0",
     "jinja2>=2.11.0,<4.0.0",
     "IPython>=7.0.0,<10.0.0",
     "matplotlib>=3.3.0,<4.0.0",
     "tornado>=6.0,<7.0",
     "pandas>=1.0.0,<3.0.0",
-    "soundfile>=0.10.0,<1.0.0",
+]
+
+[project.optional-dependencies]
+embeddings = [
+    "torch>=1.9.0,<3.0.0",
     "laserembeddings>=1.0.0,<2.0.0",
     "bert-score>=0.3.0,<1.0.0",
+]
+audio = [
+    "soundfile>=0.10.0,<1.0.0",
+]
+translate = [
+    "google-cloud-translate>=3.0.0,<4.0.0",
+]
+all = [
+    "vizseq[embeddings,audio,translate]",
 ]
 
 [project.urls]

--- a/vizseq/_data/data_sources.py
+++ b/vizseq/_data/data_sources.py
@@ -15,10 +15,25 @@ from enum import Enum
 import base64
 
 import numpy as np
-import soundfile as sf
 
 TXT_EXT = '.txt'
 ZIP_EXT = '.zip'
+
+
+def _import_soundfile():
+    """Lazily import the optional ``soundfile`` dependency.
+
+    Raises a helpful error if the ``audio`` extra is not installed.
+    """
+    try:
+        import soundfile as sf
+    except ImportError as e:
+        raise ImportError(
+            'Reading audio data requires the optional "soundfile" '
+            'dependency. Install it with: pip install vizseq[audio]'
+        ) from e
+    return sf
+
 
 PathOrPathsOrDictOfStrList = Union[str, List[str], Dict[str, List[str]]]
 
@@ -171,7 +186,7 @@ class VizSeqDataSourceBase(object):
             return len(self.data[idx]) if finer else len(self.data[idx].split())
         elif self.is_audio:
             if any(self.data[idx].endswith(e) for e in SOUNDFILE_FILE_EXTS):
-                sound, sr = sf.read(self.data[idx])
+                sound, sr = _import_soundfile().read(self.data[idx])
                 duration_ms = int(len(sound) / sr * 1000)
                 n_frames = int(1 + (duration_ms - 25) / 10)
                 return duration_ms if finer else n_frames
@@ -189,7 +204,7 @@ class VizSeqDataSourceBase(object):
     def get_audio(self, idx) -> Optional[Tuple[np.ndarray, int]]:
         if not self.is_audio:
             return None
-        sound, sample_rate = sf.read(self.data[idx])
+        sound, sample_rate = _import_soundfile().read(self.data[idx])
         return sound, sample_rate
 
     @property
@@ -283,7 +298,7 @@ class VizSeqZipFileSource(VizSeqDataSourceBase):
             if any(self.data[idx].endswith(e) for e in SOUNDFILE_FILE_EXTS):
                 with zipfile.ZipFile(self.path) as zip_f:
                     with zip_f.open(self.data[idx], 'r') as f:
-                        sound, sr = sf.read(f)
+                        sound, sr = _import_soundfile().read(f)
                         duration_ms = int(len(sound) / sr * 1000)
                         n_frames = int(1 + (duration_ms - 25) / 10)
                         return duration_ms if finer else n_frames
@@ -294,7 +309,7 @@ class VizSeqZipFileSource(VizSeqDataSourceBase):
             return None
         with zipfile.ZipFile(self.path) as zip_f:
             with zip_f.open(self.data[idx], 'r') as f:
-                sound, sample_rate = sf.read(f)
+                sound, sample_rate = _import_soundfile().read(f)
         return sound, sample_rate
 
 

--- a/vizseq/_data/google_translate.py
+++ b/vizseq/_data/google_translate.py
@@ -9,9 +9,6 @@ import os
 from functools import lru_cache
 from typing import Optional
 
-from google.cloud import translate
-from google.api_core import exceptions as google_exceptions
-
 from vizseq._utils.logger import logger
 
 
@@ -45,6 +42,15 @@ def get_g_translate(sent: str, lang: str) -> Optional[str]:
     Returns:
         Translated text, or None if translation fails.
     """
+    try:
+        from google.cloud import translate
+        from google.api_core import exceptions as google_exceptions
+    except ImportError as e:
+        raise ImportError(
+            'Google Translate integration requires the optional '
+            '"google-cloud-translate" dependency. Install it with: '
+            'pip install vizseq[translate]'
+        ) from e
     try:
         client = translate.Client()
         t = client.translate(sent, target_language=lang)['translatedText']

--- a/vizseq/scorers/__init__.py
+++ b/vizseq/scorers/__init__.py
@@ -229,4 +229,9 @@ scorer_filenames = sorted(
 for m in scorer_filenames:
     module_name = f'vizseq.scorers.{os.path.splitext(os.path.basename(m))[0]}'
     if module_name not in sys.modules:
-        importlib.import_module(module_name)
+        try:
+            importlib.import_module(module_name)
+        except ImportError:
+            # A scorer may depend on an optional extra (e.g. embeddings).
+            # Skip registering it rather than breaking the whole registry.
+            pass

--- a/vizseq/scorers/bert_score.py
+++ b/vizseq/scorers/bert_score.py
@@ -19,7 +19,13 @@ class BERTScoreScorer(VizSeqScorer):
     ) -> VizSeqScore:
         corpus_score, sent_scores, group_scores = None, None, None
 
-        import bert_score as bs
+        try:
+            import bert_score as bs
+        except ImportError as e:
+            raise ImportError(
+                'The BERTScore scorer requires the optional "bert-score" '
+                'dependency. Install it with: pip install vizseq[embeddings]'
+            ) from e
         import langid
         import logging
         logging.getLogger('transformers').setLevel(logging.WARNING)

--- a/vizseq/scorers/laser.py
+++ b/vizseq/scorers/laser.py
@@ -22,7 +22,13 @@ def set_up():
     if _setup_complete:
         return
 
-    import laserembeddings
+    try:
+        import laserembeddings
+    except ImportError as e:
+        raise ImportError(
+            'The LASER scorer requires the optional "laserembeddings" '
+            'dependency. Install it with: pip install vizseq[embeddings]'
+        ) from e
     try:
         laserembeddings.Laser().embed_sentences(['This is a test.'], lang='en')
     except FileNotFoundError:


### PR DESCRIPTION
## Motivation

Currently `pip install vizseq` pulls in `torch`, `laserembeddings`, `bert-score`, `soundfile`, and `google-cloud-translate` as **required** dependencies. A user who only wants n-gram scoring (BLEU, chrF, etc.) or basic visualization ends up downloading ~2GB — most of it `torch` and its transitive deps.

This PR moves those heavy dependencies out of the required set into optional extras, keeping the base install lightweight while leaving the full feature set one `pip install` flag away.

## Changes

- **`pyproject.toml`** — split dependencies into a lightweight core plus optional extras:
  - `embeddings` → `torch`, `laserembeddings`, `bert-score` (LASER + BERTScore scorers)
  - `audio` → `soundfile` (reading `.wav`/`.flac`/`.sph` sources)
  - `translate` → `google-cloud-translate` (Google Translate integration)
  - `all` → everything above
- **Deferred eager imports** so `import vizseq` still works when an extra is absent:
  - `vizseq/_data/data_sources.py` — `soundfile` moved into a lazy `_import_soundfile()` helper with a friendly install hint; the 4 `sf.read()` call sites updated.
  - `vizseq/_data/google_translate.py` — `google.cloud`/`google.api_core` imports moved into `get_g_translate()` with a friendly error.
- **Resilient scorer registry** (`vizseq/scorers/__init__.py`) — the auto-import loop now skips a scorer whose optional dependency is missing instead of crashing the whole registry. LASER/BERTScore still register (they lazy-import) and raise a clear `pip install vizseq[embeddings]` message only when actually invoked.
- **`README.md`** — documented the new extras.

## Test Plan

Validated in a clean virtualenv with **zero optional deps installed**:

- Core-only `pip install -e .` completes in ~21s (confirmed `torch`/`soundfile`/`google-cloud-translate` absent).
- All 15 scorers still register; BLEU/chrF run and produce correct scores.
- Text data sources work without `soundfile`.
- Each optional path raises its friendly, actionable `ImportError` when used without the extra:
  - `soundfile` → `pip install vizseq[audio]`
  - Google Translate → `pip install vizseq[translate]`
  - LASER / BERTScore → `pip install vizseq[embeddings]`
- `flake8` clean on all changed files; extras metadata resolves correctly (`torch`/`soundfile`/`google-cloud-translate` all gated behind `extra ==`).

## Related Issues and PRs

Follow-up to the packaging modernization in #108.