### PR TITLE
Harden web rendering and fix pagination edge cases

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -57,6 +57,7 @@ jobs:
         run: bash get_example_data.sh
       - run: python -m tests.test_n_gram_based_scorers
       - run: python -m tests.test_ipynb
+      - run: python -m tests.test_web
 
   embeddings:
     needs: lint

--- a/tests/test_web.py
+++ b/tests/test_web.py
@@ -1,0 +1,211 @@
+# Copyright (c) Facebook, Inc. and its affiliates.
+# All rights reserved.
+#
+# This source code is licensed under the license found in the
+# LICENSE file in the root directory of this source tree.
+
+import argparse
+import io
+import json
+import os
+import tempfile
+import unittest
+import urllib.parse
+import zipfile
+
+from tornado.testing import AsyncHTTPTestCase
+
+from vizseq import server
+from vizseq._data import VizSeqDataSources
+from vizseq._view.data_view import VizSeqDataPageView
+from vizseq._view import mem_cached_data_getters
+
+
+XSS_PAYLOAD = '</script><script>alert("vizseq-xss")</script>'
+
+
+def _clear_data_caches():
+    mem_cached_data_getters._get_src.cache_clear()
+    mem_cached_data_getters._get_ref.cache_clear()
+    mem_cached_data_getters._get_tag.cache_clear()
+    mem_cached_data_getters._get_scores.cache_clear()
+    mem_cached_data_getters.__get_hypo.cache_clear()
+
+
+class VizSeqDataPageViewTestCase(unittest.TestCase):
+    def setUp(self):
+        lines = ['zero', 'one', 'two', 'three', 'four', 'five']
+        self.sources = VizSeqDataSources({'source': lines})
+        self.references = VizSeqDataSources({'reference': lines})
+        self.hypothesis = VizSeqDataSources({'model': lines})
+
+    def test_empty_search_returns_an_empty_page(self):
+        page = VizSeqDataPageView.get(
+            self.sources,
+            self.references,
+            self.hypothesis,
+            page_sz=2,
+            page_no=1,
+            query='not present',
+            disable_alignment=True,
+        )
+
+        self.assertEqual(page.cur_idx, [])
+        self.assertEqual(page.n_samples, 0)
+        self.assertEqual(page.n_cur_samples, 0)
+
+    def test_out_of_range_page_is_clamped_to_the_last_full_page(self):
+        page = VizSeqDataPageView.get(
+            self.sources,
+            self.references,
+            self.hypothesis,
+            page_sz=2,
+            page_no=99,
+            disable_alignment=True,
+        )
+
+        self.assertEqual(page.cur_idx, [4, 5])
+
+
+class VizSeqWebTestCase(AsyncHTTPTestCase):
+    def setUp(self):
+        self.temp_dir = tempfile.TemporaryDirectory()
+        self.old_home = os.environ.get('HOME')
+        os.environ['HOME'] = self.temp_dir.name
+        self.data_root = os.path.join(self.temp_dir.name, 'data')
+        self.task_root = os.path.join(self.data_root, 'test_task')
+        os.makedirs(self.task_root)
+
+        sources = ['zero', XSS_PAYLOAD, 'two', 'three', 'four', 'five']
+        references = ['zero', 'one', 'two', 'three', 'four', 'five']
+        predictions = ['wrong', 'one', 'wrong', 'three', 'wrong', 'five']
+        tags = ['safe', XSS_PAYLOAD, 'safe', 'safe', 'safe', 'safe']
+        self._write_lines('src_0.txt', sources)
+        self._write_lines('ref_0.txt', references)
+        self._write_lines('pred_model.txt', predictions)
+        self._write_lines('tag_0.txt', tags)
+
+        server.args = argparse.Namespace(data_root=self.data_root)
+        _clear_data_caches()
+        super().setUp()
+
+    def tearDown(self):
+        super().tearDown()
+        _clear_data_caches()
+        if self.old_home is None:
+            os.environ.pop('HOME', None)
+        else:
+            os.environ['HOME'] = self.old_home
+        self.temp_dir.cleanup()
+
+    def get_app(self):
+        return server.make_app()
+
+    def _write_lines(self, filename, lines):
+        with open(os.path.join(self.task_root, filename), 'w') as file:
+            file.write('\n'.join(lines) + '\n')
+
+    def _view_url(self, **params):
+        query = {'t': 'test_task', 'm': 'model'}
+        query.update(params)
+        return '/view?' + urllib.parse.urlencode(query)
+
+    @staticmethod
+    def _multipart_zip(filename, zip_bytes):
+        boundary = b'vizseq-test-boundary'
+        body = b'\r\n'.join([
+            b'--' + boundary,
+            b'Content-Disposition: form-data; name="file1"; filename="'
+            + filename.encode('ascii') + b'"',
+            b'Content-Type: application/zip',
+            b'',
+            zip_bytes,
+            b'--' + boundary + b'--',
+            b'',
+        ])
+        content_type = 'multipart/form-data; boundary=' + boundary.decode('ascii')
+        return body, content_type
+
+    def test_view_escapes_script_payloads_in_html_and_javascript(self):
+        response = self.fetch(self._view_url(q=XSS_PAYLOAD))
+        body = response.body.decode('utf-8')
+
+        self.assertEqual(response.code, 200)
+        self.assertNotIn(XSS_PAYLOAD, body)
+        self.assertIn(r'\u003c/script\u003e', body)
+        self.assertIn('&lt;/script&gt;', body)
+        self.assertNotIn('javascript:getGTranslate', body)
+
+    def test_empty_search_renders_a_valid_empty_state(self):
+        response = self.fetch(self._view_url(q='not present'))
+
+        self.assertEqual(response.code, 200)
+        self.assertIn(
+            b'No examples match the current search.', response.body
+        )
+
+    def test_invalid_pagination_and_sorting_return_400(self):
+        for params in ({'p_no': 0}, {'p_sz': 101}, {'s': 999}):
+            with self.subTest(params=params):
+                response = self.fetch(self._view_url(**params))
+                self.assertEqual(response.code, 400)
+
+    def test_page_data_forwards_metric_sorting_and_returns_json(self):
+        query = urllib.parse.urlencode({
+            't': 'test_task',
+            'm': 'model',
+            's': 6,
+            's_metric': 'wer',
+        })
+        response = self.fetch('/page_data?' + query)
+        payload = json.loads(response.body)
+
+        self.assertEqual(response.code, 200)
+        self.assertTrue(
+            response.headers['Content-Type'].startswith('application/json')
+        )
+        self.assertEqual(payload['cur_idx'][:3], [1, 3, 5])
+
+    def test_page_tags_follow_paginated_indices(self):
+        response = self.fetch(self._view_url(p_sz=2, p_no=2))
+        body = response.body.decode('utf-8')
+
+        self.assertEqual(response.code, 200)
+        self.assertNotIn('badge badge-primary">&lt;/script', body)
+
+    def test_upload_rejects_path_traversal_and_removes_temporary_zip(self):
+        archive = io.BytesIO()
+        with zipfile.ZipFile(archive, 'w') as zip_file:
+            zip_file.writestr('../escaped.txt', 'unsafe')
+        body, content_type = self._multipart_zip('malicious.zip', archive.getvalue())
+
+        response = self.fetch(
+            '/upload',
+            method='POST',
+            headers={'Content-Type': content_type},
+            body=body,
+            follow_redirects=False,
+        )
+
+        self.assertEqual(response.code, 400)
+        self.assertFalse(os.path.exists(os.path.join(self.data_root, 'malicious.zip')))
+        self.assertFalse(os.path.exists(os.path.join(self.temp_dir.name, 'escaped.txt')))
+
+    def test_upload_rejects_corrupt_archives_and_missing_files(self):
+        body, content_type = self._multipart_zip('corrupt.zip', b'not a zip')
+        corrupt_response = self.fetch(
+            '/upload',
+            method='POST',
+            headers={'Content-Type': content_type},
+            body=body,
+            follow_redirects=False,
+        )
+        missing_response = self.fetch('/upload', method='POST', body=b'')
+
+        self.assertEqual(corrupt_response.code, 400)
+        self.assertEqual(missing_response.code, 400)
+        self.assertFalse(os.path.exists(os.path.join(self.data_root, 'corrupt.zip')))
+
+
+if __name__ == '__main__':
+    unittest.main()

--- a/vizseq/_templates/base.html
+++ b/vizseq/_templates/base.html
@@ -24,21 +24,15 @@
 
 <body>
 
-<script>
-  function goTo(endpoint) {
-    window.location.href = location.protocol + '//' + location.hostname + ':' + location.port + '/' + endpoint;
-  }
-</script>
-
 <header>
   <nav class="navbar navbar-expand-lg navbar-dark fixed-top" style="background-color:#3b5998">
-    <a class="navbar-brand" href="javascript:goTo('about');">VizSeq</a>
+    <a class="navbar-brand" href="/about">VizSeq</a>
     <div class="collapse navbar-collapse" id="navbarCollapse">
       <ul class="navbar-nav mr-auto">
-        <li class="nav-item active"><a class="nav-link" href="javascript:goTo('');">Tasks</a></li>
-        <li class="nav-item active"><a class="nav-link" href="javascript:goTo('upload');">Upload</a></li>
-        <li class="nav-item active"><a class="nav-link" href="javascript:goTo('config');">Configuration</a></li>
-        <li class="nav-item active"><a class="nav-link" href="javascript:goTo('about');">About</a></li>
+        <li class="nav-item active"><a class="nav-link" href="/">Tasks</a></li>
+        <li class="nav-item active"><a class="nav-link" href="/upload">Upload</a></li>
+        <li class="nav-item active"><a class="nav-link" href="/config">Configuration</a></li>
+        <li class="nav-item active"><a class="nav-link" href="/about">About</a></li>
       </ul>
     </div>
   </nav>

--- a/vizseq/_templates/macros.html
+++ b/vizseq/_templates/macros.html
@@ -19,26 +19,28 @@
 
 <script>
     function updateStatsTable(stats) {
+        function appendCell(row, tagName, value, scope) {
+            let cell = document.createElement(tagName);
+            if (scope) { cell.setAttribute('scope', scope); }
+            cell.textContent = value;
+            row.appendChild(cell);
+        }
         enum_src_names_and_types.forEach(function (e) {
             let trNode = document.createElement('tr');
-            trNode.innerHTML +=
-                `<th scope="row">Source ${e[1]}</th>
-                     <td>${e[2]}</td>
-                     <td>${stats['n_examples']}</td>
-                     <td>${stats['n_src_tokens'][e[1]]}</td>
-                     <td>${stats['n_src_chars'][e[1]]}</td>`
-            ;
+            appendCell(trNode, 'th', 'Source ' + e[1], 'row');
+            appendCell(trNode, 'td', e[2]);
+            appendCell(trNode, 'td', stats['n_examples']);
+            appendCell(trNode, 'td', stats['n_src_tokens'][e[1]]);
+            appendCell(trNode, 'td', stats['n_src_chars'][e[1]]);
             document.getElementById('statsTable').appendChild(trNode);
         });
         enum_ref_names.forEach(function (e) {
             let trNode = document.createElement('tr');
-            trNode.innerHTML +=
-                `<th scope="row">Reference ${e[1]}</th>
-                     <td>Text</td>
-                     <td>${stats['n_examples']}</td>
-                     <td>${stats['n_ref_tokens'][e[1]]}</td>
-                     <td>${stats['n_ref_chars'][e[1]]}</td>`
-            ;
+            appendCell(trNode, 'th', 'Reference ' + e[1], 'row');
+            appendCell(trNode, 'td', 'Text');
+            appendCell(trNode, 'td', stats['n_examples']);
+            appendCell(trNode, 'td', stats['n_ref_tokens'][e[1]]);
+            appendCell(trNode, 'td', stats['n_ref_chars'][e[1]]);
             document.getElementById('statsTable').appendChild(trNode);
         });
     }
@@ -52,7 +54,7 @@
         {% if group1|length > 0 %}
         {% for i in group1 %}
         <li class="page-item">
-            <a class="page-link" href="javascript:deriveURL(urlArgs, &quot;p_no&quot;, &quot;{{ i }}&quot;);">{{ i }}</a>
+            <a class="page-link" href="#" onclick="deriveURL(urlArgs, 'p_no', '{{ i }}'); return false;">{{ i }}</a>
         </li>
         {% endfor %}
         <li class="page-item">&emsp;&emsp;</li>
@@ -60,7 +62,7 @@
 
         {% for i in group2 %}
         <li class="page-item">
-            <a class="page-link" href="javascript:deriveURL(urlArgs, &quot;p_no&quot;, &quot;{{ i }}&quot;);">{{ i }}</a>
+            <a class="page-link" href="#" onclick="deriveURL(urlArgs, 'p_no', '{{ i }}'); return false;">{{ i }}</a>
         </li>
         {% endfor %}
 
@@ -70,7 +72,7 @@
 
         {% for i in group3 %}
         <li class="page-item">
-            <a class="page-link" href="javascript:deriveURL(urlArgs, &quot;p_no&quot;, &quot;{{ i }}&quot;);">{{ i }}</a>
+            <a class="page-link" href="#" onclick="deriveURL(urlArgs, 'p_no', '{{ i }}'); return false;">{{ i }}</a>
         </li>
         {% endfor %}
 
@@ -78,7 +80,7 @@
         <li class="page-item">&emsp;&emsp;</li>
         {% for i in group4 %}
         <li class="page-item">
-            <a class="page-link" href="javascript:deriveURL(urlArgs, &quot;p_no&quot;, &quot;{{ i }}&quot;);">{{ i }}</a>
+            <a class="page-link" href="#" onclick="deriveURL(urlArgs, 'p_no', '{{ i }}'); return false;">{{ i }}</a>
         </li>
         {% endfor %}
         {% endif %}

--- a/vizseq/_templates/view.html
+++ b/vizseq/_templates/view.html
@@ -9,23 +9,22 @@
 <div class="container"><br><h3>{{ task_name }}</h3><br></div>
 
 {{ span_highlight_js }}
-{% from 'macros.html' import nav_pages, stats_table, visualize_dict, copy_to_clipboard %}
+{% from 'macros.html' import nav_pages, stats_table, copy_to_clipboard %}
 
-{{ visualize_dict() }}
 {{ copy_to_clipboard() }}
 
 <script>
-    const urlArgs = {{ url_args|safe }};
-    const task = '{{ task }}';
-    const taskName = '{{ task_name }}';
-    const models = {{ models|safe }};
-    const tagSet = {{ tag_set|safe }};
-    const enum_src_names_and_types = {{ enum_src_names_and_types|safe }};
-    const enum_ref_names = {{ enum_ref_names|safe }};
-    const enum_metrics_and_names = {{ enum_metrics_and_names|safe }};
-    const all_metrics_and_names = {{ all_metrics_and_names|safe }};
-    const allTokenization = {{ all_tokenization|safe }};
-    const tokenization = '{{ tokenization }}';
+    const urlArgs = {{ url_args|tojson }};
+    const task = {{ task|tojson }};
+    const taskName = {{ task_name|tojson }};
+    const models = {{ models|tojson }};
+    const tagSet = {{ tag_set|tojson }};
+    const enum_src_names_and_types = {{ enum_src_names_and_types|tojson }};
+    const enum_ref_names = {{ enum_ref_names|tojson }};
+    const enum_metrics_and_names = {{ enum_metrics_and_names|tojson }};
+    const all_metrics_and_names = {{ all_metrics_and_names|tojson }};
+    const allTokenization = {{ all_tokenization|tojson }};
+    const tokenization = {{ tokenization|tojson }};
 
     const plotCfg = {
         responsive: true,
@@ -53,23 +52,31 @@
     function deriveURL(args, key, newValue) {
         let newArgs = JSON.parse(JSON.stringify(args));
         newArgs[key] = newValue;
-        let pairs = Object.keys(newArgs).map(k => k + "=" + newArgs[k]);
-        window.location.href = location.protocol + "//" + location.hostname + ":" + location.port + location.pathname +
-            "?" + pairs.join("&");
+        let url = new URL(window.location.href);
+        url.search = '';
+        Object.keys(newArgs).forEach(k => url.searchParams.set(k, newArgs[k]));
+        window.location.assign(url.toString());
     }
 
-    function getGTranslate(selfId, srcRowId, sent, lang) {
+    function getGTranslate(link, srcRowId) {
         let callback = function(jsonResponse) {
             let trNode = document.createElement('tr');
             trNode.setAttribute('style', 'background-color:#EAF2F8');
-            trNode.innerHTML = '<th class="text-nowrap text-left" scope="row">Google Translate</th><td>' +
-                jsonResponse['translation'] + '</td>';
+            let heading = document.createElement('th');
+            heading.className = 'text-nowrap text-left';
+            heading.setAttribute('scope', 'row');
+            heading.textContent = 'Google Translate';
+            let translation = document.createElement('td');
+            translation.textContent = jsonResponse['translation'];
+            trNode.appendChild(heading);
+            trNode.appendChild(translation);
             document.getElementById(srcRowId).after(trNode);
-            $('#' + selfId).remove();
+            link.remove();
         };
-        let url = location.protocol + '//' + location.hostname + ':' + location.port + "/g_translate?s=" +
-            encodeURIComponent(sent) + "&l=" +  encodeURIComponent(lang);
-        doJsonAjax(url, callback);
+        let url = new URL('/g_translate', window.location.origin);
+        url.searchParams.set('s', link.dataset.sent);
+        url.searchParams.set('l', link.dataset.lang);
+        doJsonAjax(url.toString(), callback);
     }
 
     function submitSearchForm() {
@@ -266,7 +273,8 @@
                                 {% if src_type == 'text' %}
                                 <td class="text-left">
                                     {{ cur_viz_src }}
-                                    <a href="javascript:getGTranslate('gTranslate{{ j }}_{{ i }}', 'srcRow{{ j }}_{{ i }}', '{{ cur_src }}', '{{ trg_lang[i] }}');"
+                                    <a href="#" data-sent="{{ cur_src }}" data-lang="{{ trg_lang[i] }}"
+                                       onclick="getGTranslate(this, 'srcRow{{ j }}_{{ i }}'); return false;"
                                        title="Google Translate" id="gTranslate{{ j }}_{{ i }}">GTranslate</a>
                                 </td>
                                 {% elif src_type == 'image' %}
@@ -321,6 +329,10 @@
                 </div>
                 <br>
                 {% endfor %}
+
+                {% if n_samples == 0 %}
+                <div class="alert alert-info" role="status">No examples match the current search.</div>
+                {% endif %}
 
                 <br>
                 {{ nav_pages(page_no, pagination[0], pagination[1], pagination[2], pagination[3]) }}
@@ -540,6 +552,69 @@
             Plotly.newPlot("sentScoresPlot4" + metric, data, layout, plotCfg);
         }
 
+        function appendScoreRow(tbodyNode, label, scores) {
+            let values = models.map(m => scores[m]);
+            let worstValue = Math.min(...values);
+            let bestValue = Math.max(...values);
+            let row = document.createElement('tr');
+            let heading = document.createElement('th');
+            heading.setAttribute('scope', 'row');
+            heading.textContent = label;
+            row.appendChild(heading);
+            models.forEach(function (model) {
+                let cell = document.createElement('td');
+                cell.textContent = scores[model];
+                if (scores[model] === worstValue) {
+                    cell.style.fontStyle = 'italic';
+                    cell.style.textDecoration = 'underline';
+                } else if (scores[model] === bestValue) {
+                    cell.style.fontWeight = 'bold';
+                }
+                row.appendChild(cell);
+            });
+            tbodyNode.appendChild(row);
+        }
+
+        function appendNGramTable(container, n, entries) {
+            let column = document.createElement('div');
+            column.className = 'col';
+            let table = document.createElement('table');
+            table.className = 'table table-hover table-sm table-bordered text-center';
+            let thead = document.createElement('thead');
+            thead.className = 'thead-light';
+            let headingRow = document.createElement('tr');
+            [n + '-Gram', 'Count'].forEach(function (label) {
+                let heading = document.createElement('th');
+                heading.setAttribute('scope', 'col');
+                heading.textContent = label;
+                headingRow.appendChild(heading);
+            });
+            thead.appendChild(headingRow);
+            table.appendChild(thead);
+
+            let tbody = document.createElement('tbody');
+            entries.forEach(function (entry) {
+                let row = document.createElement('tr');
+                let ngramCell = document.createElement('td');
+                let link = document.createElement('a');
+                link.href = '#';
+                link.textContent = entry[0];
+                link.addEventListener('click', function (event) {
+                    event.preventDefault();
+                    deriveURL(urlArgs, 'q', entry[0]);
+                });
+                ngramCell.appendChild(link);
+                let countCell = document.createElement('td');
+                countCell.textContent = entry[1];
+                row.appendChild(ngramCell);
+                row.appendChild(countCell);
+                tbody.appendChild(row);
+            });
+            table.appendChild(tbody);
+            column.appendChild(table);
+            container.appendChild(column);
+        }
+
         doJsonAjax('/stats?t=' + urlArgs['t'], function (jsonData) {
             plotSentenceLength(jsonData['src_lens'], jsonData['ref_lens']);
             plotTokenFrequency('srcTknFreqPlot', jsonData['src_tkn_log2_freq'], 'Source');
@@ -556,21 +631,15 @@
                     let s = e[1];
                     plotSentScores(jsonData['sent_scores'], s);
 
-                    document.getElementById('latex_' + s).innerText = jsonData['corpus_group_scores_latex'];
-                    document.getElementById('csv_' + s).innerText = jsonData['corpus_group_scores_csv'];
-                    let corpusScores = visualizeDict(jsonData['corpus_scores'][s]);
+                    document.getElementById('latex_' + s).textContent =
+                        jsonData['corpus_group_scores_latex'][s];
+                    document.getElementById('csv_' + s).textContent =
+                        jsonData['corpus_group_scores_csv'][s];
 
                     let tbodyNode = document.getElementById('tableBodyMetric_' + s);
-                    let trNode1 = document.createElement('tr');
-                    let tdNodes1 = models.map(m => '<td>' + corpusScores[m] + '</td>');
-                    trNode1.innerHTML = '<th scope="row">All</th>' + tdNodes1.join('');
-                    tbodyNode.appendChild(trNode1);
+                    appendScoreRow(tbodyNode, 'All', jsonData['corpus_scores'][s]);
                     tagSet.forEach(function (t) {
-                        let groupScores = visualizeDict(jsonData['group_scores'][s][t]);
-                        let trNode = document.createElement('tr');
-                        let tdNodes = models.map(m => '<td>' + groupScores[m] + '</td>');
-                        trNode.innerHTML = '<th scope="row">' + t + '</th>' + tdNodes.join('');
-                        tbodyNode.appendChild(trNode);
+                        appendScoreRow(tbodyNode, t, jsonData['group_scores'][s][t]);
                     });
 
                     $('#' + s + 'ScoreSpinner').remove();
@@ -579,29 +648,11 @@
         }
 
         doJsonAjax('/ngrams?t=' + urlArgs['t'], function (jsonData) {
+            let container = document.getElementById('ngramsDiv');
             Object.keys(jsonData).forEach(function (n) {
-                let theadHTML =
-                    `<thead class="thead-light">
-                        <tr><th scope="col">${n}-Gram</th><th scope="col">Count</th></tr>
-                    </thead>`;
-                let trHTMLs = jsonData[n].map(
-                    t =>
-                        `<tr>
-                            <td><a href="javascript:deriveURL(urlArgs, 'q', '${t[0]}');">${t[0]}</a></td>
-                            <td>${t[1]}</td>
-                        </tr>`
-                );
-                let tbodyHTML = `<tbody>${trHTMLs.join('')}</tbody>`;
-
-                let colHTML =
-                    `<div class="col">
-                        <table class="table table-hover table-sm table-bordered text-center">
-                            ${theadHTML}${tbodyHTML}
-                        </table>
-                    </div>`;
-                document.getElementById('ngramsDiv').innerHTML += colHTML;
-                $('#ngramsSpinner').remove();
+                appendNGramTable(container, n, jsonData[n]);
             });
+            $('#ngramsSpinner').remove();
         });
 
         resetTaskCfgMetrics();

--- a/vizseq/_view/__init__.py
+++ b/vizseq/_view/__init__.py
@@ -6,7 +6,8 @@
 #
 
 from .web_view import VizSeqWebView
-from .data_view import VizSeqDataPageView, DEFAULT_PAGE_SIZE, DEFAULT_PAGE_NO
+from .data_view import (VizSeqDataPageView, DEFAULT_PAGE_SIZE, DEFAULT_PAGE_NO,
+                        MAX_PAGE_SZ)
 from .data_filter import VizSeqFilter
 from .data_sorters import (VizSeqSortingType, VizSeqRandomSorter,
                            VizSeqByLenSorter, VizSeqByStrOrderSorter,

--- a/vizseq/_view/data_view.py
+++ b/vizseq/_view/data_view.py
@@ -34,10 +34,14 @@ MAX_PAGE_SZ = 100
 def _get_start_end_idx(n_items: int, page_sz: int, page_no: int) -> Tuple[int, int]:
     if page_sz <= 0 or page_no <= 0:
         raise ValueError("page_sz and page_no must be positive integers")
-    if n_items <= 0:
-        raise ValueError("n_items must be positive")
-    start_idx = min(page_sz * (page_no - 1), n_items - 1)
-    end_idx = max(page_sz * page_no - 1, start_idx)
+    if n_items < 0:
+        raise ValueError("n_items must be non-negative")
+    if n_items == 0:
+        return 0, -1
+    n_pages = int(np.ceil(n_items / page_sz))
+    page_no = min(page_no, n_pages)
+    start_idx = page_sz * (page_no - 1)
+    end_idx = min(start_idx + page_sz, n_items) - 1
     # inclusive on both sides
     return start_idx, end_idx
 
@@ -98,6 +102,26 @@ class VizSeqDataPageView(object):
         elif ref.has_text:
             cur_idx = VizSeqFilter.filter(ref.text, query)
         n_samples = len(cur_idx)
+
+        if n_samples == 0:
+            cur_src = src.cached([])
+            cur_src_text = [] if src.has_text else None
+            cur_ref = [[] for _ in ref.text]
+            cur_hypo = {name: [] for name in models}
+            return VizSeqPageData(
+                viz_src=cur_src,
+                viz_ref=cur_ref,
+                viz_hypo=cur_hypo,
+                cur_src=cur_src,
+                cur_src_text=cur_src_text,
+                cur_ref=cur_ref,
+                cur_idx=[],
+                viz_sent_scores=[],
+                trg_lang=[] if need_lang_tags else None,
+                n_cur_samples=0,
+                n_samples=0,
+                total_examples=len(src),
+            )
 
         # sorting
         sorting = {e.value: e for e in VizSeqSortingType}.get(sorting, None)

--- a/vizseq/_view/web_view.py
+++ b/vizseq/_view/web_view.py
@@ -51,7 +51,9 @@ class VizSeqWebView(object):
         self.query = query
         self.sorting = sorting
         self.sorting_metric = sorting_metric
-        set_g_cred_path(VizSeqGlobalConfigManager().g_cred_path)
+        g_cred_path = VizSeqGlobalConfigManager().g_cred_path
+        if g_cred_path:
+            set_g_cred_path(g_cred_path)
         src = _get_src(self.dir_path)
         self.src_has_text = src.has_text
         self.enum_src_names_and_types = self.get_enum(
@@ -161,7 +163,7 @@ class VizSeqWebView(object):
     def get_page_data_with_pagination(self) -> str:
         page_data = self.get_page_data()._asdict()
         page_data['pagination'] = self.get_pagination(
-            page_data['total_examples'], self.page_sz, self.page_no
+            page_data['n_samples'], self.page_sz, self.page_no
         )
         return json.dumps(page_data)
 
@@ -173,6 +175,8 @@ class VizSeqWebView(object):
             raise ValueError(f'page_sz must be positive, got {page_sz}')
         if page_no <= 0:
             raise ValueError(f'page_no must be positive, got {page_no}')
+        if total_examples <= 0:
+            return [], [], [], []
         n_pages = math.ceil(total_examples / page_sz)
         _page_no = min(max(1, page_no), n_pages)
 

--- a/vizseq/server.py
+++ b/vizseq/server.py
@@ -10,16 +10,20 @@ import os
 import os.path as op
 import argparse
 import re
+import math
+import zipfile
 from typing import List
 
 from vizseq._utils.logger import logger
 
-from vizseq._view import VizSeqWebView, DEFAULT_PAGE_SIZE, DEFAULT_PAGE_NO
+from vizseq._view import (VizSeqWebView, DEFAULT_PAGE_SIZE, DEFAULT_PAGE_NO,
+                          MAX_PAGE_SZ, VizSeqSortingType)
 from vizseq._data.zip_file import VizSeqZipFile, ZipExtractionError
 from vizseq._data import get_g_translate, VizSeqGlobalConfigManager
 from vizseq._visualizers import SPAN_HIGHTLIGHT_JS
 from vizseq._utils import VizSeqJson
 from vizseq import __version__
+from vizseq.scorers import get_scorer_ids
 
 from tornado import web, ioloop
 from jinja2 import Environment, PackageLoader, select_autoescape
@@ -77,6 +81,10 @@ def sanitize_filename(filename: str) -> str:
 
 
 class VizSeqBaseRequestHandler(web.RequestHandler):
+    def write_json(self, value: str) -> None:
+        self.set_header('Content-Type', 'application/json')
+        self.write(value)
+
     def get_url_args(self):
         return {
             't': self.get_task_arg(), 'm': ','.join(self.get_models_arg()),
@@ -107,6 +115,10 @@ class VizSeqBaseRequestHandler(web.RequestHandler):
             value = int(p_sz)
             if value <= 0:
                 raise web.HTTPError(400, 'Page size must be a positive integer')
+            if value > MAX_PAGE_SZ:
+                raise web.HTTPError(
+                    400, f'Page size must not exceed {MAX_PAGE_SZ}'
+                )
             return value
         except ValueError:
             raise web.HTTPError(400, f'Invalid page size: {p_sz!r} is not a valid integer')
@@ -117,8 +129,8 @@ class VizSeqBaseRequestHandler(web.RequestHandler):
             return DEFAULT_PAGE_NO
         try:
             value = int(p_no)
-            if value < 0:
-                raise web.HTTPError(400, 'Page number must be a non-negative integer')
+            if value <= 0:
+                raise web.HTTPError(400, 'Page number must be a positive integer')
             return value
         except ValueError:
             raise web.HTTPError(400, f'Invalid page number: {p_no!r} is not a valid integer')
@@ -131,12 +143,22 @@ class VizSeqBaseRequestHandler(web.RequestHandler):
         if len(sorting) == 0:
             return 0
         try:
-            return int(sorting)
+            value = int(sorting)
+            valid_values = {sorting_type.value for sorting_type in VizSeqSortingType}
+            if value not in valid_values:
+                raise web.HTTPError(
+                    400, f'Sorting value must be one of {sorted(valid_values)}'
+                )
+            return value
         except ValueError:
             raise web.HTTPError(400, f'Invalid sorting value: {sorting!r} is not a valid integer')
 
     def get_sorting_metric_arg(self) -> str:
-        return self.get_query_argument('s_metric', '')
+        metric = self.get_query_argument('s_metric', '')
+        if self.get_sorting_arg() == VizSeqSortingType.metric.value:
+            if metric not in get_scorer_ids():
+                raise web.HTTPError(400, f'Invalid sorting metric: {metric!r}')
+        return metric
 
 
 class TaskListHandler(VizSeqBaseRequestHandler):
@@ -164,6 +186,12 @@ class ViewHandler(VizSeqBaseRequestHandler):
             sorting_metric=s_metric
         )
         pd = wv.get_page_data()
+        page_no = min(page_no, max(1, math.ceil(pd.n_samples / page_sz)))
+        url_args['p_no'] = str(page_no)
+        all_tags = wv.get_tags()
+        page_tags = [
+            all_tags[i] if i < len(all_tags) else [] for i in pd.cur_idx
+        ]
         html = env.get_template('view.html').render(
             url_args=url_args, task=task, models=models, page_sz=page_sz,
             page_no=page_no, sorting=sorting, query=query, metrics=wv.metrics,
@@ -172,10 +200,10 @@ class ViewHandler(VizSeqBaseRequestHandler):
             enum_ref_names=wv.enum_ref_names, trg_lang=pd.trg_lang,
             span_highlight_js=SPAN_HIGHTLIGHT_JS, page_sizes=wv.page_sizes,
             enum_metrics_and_names=wv.get_enum_metrics_and_names(),
-            tag_set=wv.get_tag_set(), tags=wv.get_tags(),
+            tag_set=wv.get_tag_set(), tags=page_tags,
             auto_tags=[[e] for e in pd.trg_lang],
             all_metrics_and_names=wv.all_metrics_and_names, s_metric=s_metric,
-            pagination=wv.get_pagination(pd.total_examples, page_sz, page_no),
+            pagination=wv.get_pagination(pd.n_samples, page_sz, page_no),
             cur_idx=pd.cur_idx, viz_src=pd.viz_src, src=pd.cur_src,
             ref=pd.viz_ref, hypo=pd.viz_hypo, n_samples=pd.n_samples,
             cur_sent_scores=pd.viz_sent_scores, description=wv.description,
@@ -190,10 +218,11 @@ class PageDataHandler(VizSeqBaseRequestHandler):
         wv = VizSeqWebView(
             args.data_root, self.get_task_arg(), models=self.get_models_arg(),
             page_sz=self.get_page_sz_arg(), page_no=self.get_page_no_arg(),
-            query=self.get_query_arg(), sorting=self.get_sorting_arg()
+            query=self.get_query_arg(), sorting=self.get_sorting_arg(),
+            sorting_metric=self.get_sorting_metric_arg()
         )
         page_data_json = wv.get_page_data_with_pagination()
-        self.write(page_data_json)
+        self.write_json(page_data_json)
 
 
 class TaskCfgHandler(VizSeqBaseRequestHandler):
@@ -218,7 +247,10 @@ class UploadHandler(VizSeqBaseRequestHandler):
         self.write(html)
 
     def post(self):
-        file1 = self.request.files['file1'][0]
+        files = self.request.files.get('file1', [])
+        if not files:
+            raise web.HTTPError(400, 'A ZIP file is required')
+        file1 = files[0]
         filename = sanitize_filename(file1['filename'])
         zip_file_path = os.path.join(args.data_root, filename)
         with open(zip_file_path, 'wb') as f:
@@ -227,7 +259,7 @@ class UploadHandler(VizSeqBaseRequestHandler):
             VizSeqZipFile.unzip(
                 args.data_root, filename, remove_after_unpacking=True
             )
-        except ZipExtractionError as e:
+        except (ZipExtractionError, zipfile.BadZipFile) as e:
             # Clean up the uploaded file if extraction fails
             if os.path.exists(zip_file_path):
                 os.remove(zip_file_path)
@@ -247,7 +279,7 @@ class ConfigHandler(VizSeqBaseRequestHandler):
         valid = op.exists(g_cred_path)
         if valid:
             VizSeqGlobalConfigManager().set_g_cred_path(g_cred_path)
-        self.write(json.dumps({'valid': valid}))
+        self.write_json(json.dumps({'valid': valid}))
 
 
 class GTranslateHandler(VizSeqBaseRequestHandler):
@@ -259,14 +291,14 @@ class GTranslateHandler(VizSeqBaseRequestHandler):
         translation = VizSeqJson.dumps(
             {'translation': get_g_translate(sent, lang)}
         )
-        self.write(translation)
+        self.write_json(translation)
 
 
 class StatsHandler(VizSeqBaseRequestHandler):
     def get(self):
         task = self.get_task_arg()
         response = VizSeqWebView(args.data_root, task).get_stats()
-        self.write(response)
+        self.write_json(response)
 
 
 class ScoresHandler(VizSeqBaseRequestHandler):
@@ -274,14 +306,14 @@ class ScoresHandler(VizSeqBaseRequestHandler):
         response = VizSeqWebView(
             args.data_root, self.get_task_arg(), self.get_models_arg()
         ).get_scores()
-        self.write(response)
+        self.write_json(response)
 
 
 class NGramsHandler(VizSeqBaseRequestHandler):
     def get(self):
         task = self.get_task_arg()
         response = VizSeqWebView(args.data_root, task).get_n_grams()
-        self.write(response)
+        self.write_json(response)
 
 
 class AboutHandler(VizSeqBaseRequestHandler):
@@ -292,20 +324,27 @@ class AboutHandler(VizSeqBaseRequestHandler):
         self.write(html)
 
 
+ROUTES = [
+    (r'/', TaskListHandler),
+    (r'/view', ViewHandler),
+    (r'/config', ConfigHandler),
+    (r'/upload', UploadHandler),
+    (r'/about', AboutHandler),
+    (r'/g_translate', GTranslateHandler),
+    (r'/stats', StatsHandler),
+    (r'/scores', ScoresHandler),
+    (r'/ngrams', NGramsHandler),
+    (r'/page_data', PageDataHandler),
+    (r'/task_cfg', TaskCfgHandler),
+]
+
+
+def make_app(debug=False):
+    return web.Application(ROUTES, debug=debug)
+
+
 def start_server(hostname=DEFAULT_HOSTNAME, port=DEFAULT_PORT, debug=False):
-    app = web.Application([
-        (r'/', TaskListHandler),
-        (r'/view', ViewHandler),
-        (r'/config', ConfigHandler),
-        (r'/upload', UploadHandler),
-        (r'/about', AboutHandler),
-        (r'/g_translate', GTranslateHandler),
-        (r'/stats', StatsHandler),
-        (r'/scores', ScoresHandler),
-        (r'/ngrams', NGramsHandler),
-        (r'/page_data', PageDataHandler),
-        (r'/task_cfg', TaskCfgHandler),
-    ], debug=debug)
+    app = make_app(debug=debug)
     app.listen(port, max_buffer_size=1024 ** 3)
     logger.info("Application Started")
     logger.info(f'You can navigate to http://{hostname}:{port}')


### PR DESCRIPTION
## Summary

- render dynamic web content with safe JSON serialization and DOM APIs to close XSS paths
- fix empty searches, pagination validation/clamping, filtered totals, page tags, and metric sorting
- return JSON responses with the correct content type and reject malformed uploads cleanly
- add focused Tornado web/security tests and run them in CI

## Testing

- `.venv/bin/python -m tests.test_web` (9 passed)
- `.venv/bin/pytest -q --ignore=tests/scorers/test_bert_score.py --ignore=tests/scorers/test_laser.py --ignore=tests/test_embedding_based_scorers.py` (42 passed)
- `.venv/bin/flake8 vizseq tests`
- `.venv/bin/bandit -q -r vizseq -ll -ii`

Optional embedding tests were excluded because the embedding extras are not installed in the base environment.