### PR TITLE
Drop Python 3.9 and 3.10 support

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -38,7 +38,7 @@ jobs:
       fail-fast: false
       matrix:
         os: [ubuntu-latest, macos-latest]
-        python-version: ["3.9", "3.10", "3.11", "3.12", "3.13"]
+        python-version: ["3.11", "3.12", "3.13"]
     runs-on: ${{ matrix.os }}
     steps:
       - uses: actions/checkout@v4
@@ -66,7 +66,7 @@ jobs:
       - uses: actions/checkout@v4
       - uses: actions/setup-python@v5
         with:
-          python-version: "3.10"
+          python-version: "3.11"
       - name: Install VizSeq with embedding dependencies
         run: pip install -e .[embeddings]
       - name: Download example data
@@ -80,8 +80,7 @@ jobs:
       - uses: actions/checkout@v4
       - uses: actions/setup-python@v5
         with:
-          # torch<2.0 (via [all] -> embeddings) ships no cp311 wheel
-          python-version: "3.10"
+          python-version: "3.11"
       - run: sudo apt-get update && sudo apt-get install -y libsndfile1
       - name: Install VizSeq
         run: pip install -e .[all] pytest pytest-cov

--- a/README.md
+++ b/README.md
@@ -44,7 +44,7 @@ a normal Python package.
 ## Getting Started
 
 ### Installation
-VizSeq requires **Python 3.9+** and currently runs on **Unix/Linux** and **macOS/OS X**. It will support **Windows** as well in the future.
+VizSeq requires **Python 3.11+** and currently runs on **Unix/Linux** and **macOS/OS X**. It will support **Windows** as well in the future.
 
 You can install VizSeq from PyPI repository:
 ```bash

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -7,13 +7,11 @@ name = "vizseq"
 version = "0.2.0"
 description = "Visual Analysis Toolkit for Text Generation Tasks"
 readme = "README.md"
-requires-python = ">=3.9"
+requires-python = ">=3.11"
 license = { file = "LICENSE" }
 classifiers = [
     "Intended Audience :: Science/Research",
     "Programming Language :: Python :: 3 :: Only",
-    "Programming Language :: Python :: 3.9",
-    "Programming Language :: Python :: 3.10",
     "Programming Language :: Python :: 3.11",
     "Programming Language :: Python :: 3.12",
     "Programming Language :: Python :: 3.13",

--- a/website/docs/getting_started/installation.md
+++ b/website/docs/getting_started/installation.md
@@ -6,7 +6,7 @@ sidebar_label: Installation
 
 import useBaseUrl from '@docusaurus/useBaseUrl';
 
-VizSeq requires **Python 3.9+** and currently runs on **Unix/Linux** and **macOS/OS X**. It will support **Windows** as
+VizSeq requires **Python 3.11+** and currently runs on **Unix/Linux** and **macOS/OS X**. It will support **Windows** as
 well in the future.
 
 You can install VizSeq from PyPI repository:


### PR DESCRIPTION
## Summary
- Bump minimum supported Python from 3.9 to 3.11 in `pyproject.toml` (`requires-python`, trove classifiers)
- Update CI matrix and pinned job Python versions accordingly (removes the now-stale `torch<2.0` cp311-wheel workaround, since `torch==1.13.1` does ship a cp311 Linux wheel)
- Update README and docs installation instructions to say Python 3.11+

## Test plan
- [x] Reviewed diff against `main` for consistency (no leftover 3.9/3.10 references)
- [x] Confirmed `torch<2.0` has a `cp311` Linux wheel (`torch==1.13.1`), so the `embeddings`/`coverage` CI jobs (which run on `ubuntu-latest`) work on Python 3.11
- [ ] CI run on this PR