### PR TITLE
Reuse BERTScore model across scoring calls

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -39,7 +39,7 @@ embeddings = [
     "torch>=1.9.0,<2.0.0",
     "transformers>=3.0.0,<4.46.0",
     "laserembeddings>=1.0.0,<2.0.0",
-    "bert-score>=0.3.0,<1.0.0",
+    "bert-score>=0.3.1,<1.0.0",
 ]
 audio = [
     "soundfile>=0.10.0,<1.0.0",

--- a/tests/scorers/test_bert_score.py
+++ b/tests/scorers/test_bert_score.py
@@ -14,12 +14,9 @@ from types import SimpleNamespace
 from unittest.mock import patch
 
 import numpy as np
+from vizseq.scorers.bert_score import _clear_bert_scorer_cache, BERTScoreScorer
 
 from . import VizSeqScorerTestCase
-from vizseq.scorers.bert_score import (
-    BERTScoreScorer,
-    _clear_bert_scorer_cache,
-)
 
 
 class BERTScoreScorerTestCase(VizSeqScorerTestCase):
@@ -38,9 +35,8 @@ class BERTScoreScorerReuseTestCase(unittest.TestCase):
         instances = []
 
         class FakeBERTScorer:
-            def __init__(self, lang, nthreads):
+            def __init__(self, lang):
                 self.lang = lang
-                self.nthreads = nthreads
                 self.calls = []
                 instances.append(self)
 
@@ -50,8 +46,8 @@ class BERTScoreScorerReuseTestCase(unittest.TestCase):
                 return scores, scores, scores
 
         modules = {
-            'bert_score': SimpleNamespace(BERTScorer=FakeBERTScorer),
-            'langid': SimpleNamespace(classify=lambda _: ('en', 1.0)),
+            "bert_score": SimpleNamespace(BERTScorer=FakeBERTScorer),
+            "langid": SimpleNamespace(classify=lambda _: ("en", 1.0)),
         }
         first_scorer = BERTScoreScorer(
             corpus_level=True, sent_level=True, n_workers=1, verbose=True
@@ -59,15 +55,14 @@ class BERTScoreScorerReuseTestCase(unittest.TestCase):
         second_scorer = BERTScoreScorer(
             corpus_level=True, sent_level=True, n_workers=1, verbose=True
         )
-        hypothesis = ['first hypothesis', 'second hypothesis']
-        references = [['first reference', 'second reference']]
+        hypothesis = ["first hypothesis", "second hypothesis"]
+        references = [["first reference", "second reference"]]
 
         with patch.dict(sys.modules, modules):
             first = first_scorer.score(hypothesis, references)
             second = second_scorer.score(hypothesis, references)
 
         self.assertEqual(len(instances), 1)
-        self.assertEqual(instances[0].nthreads, 1)
         self.assertEqual(len(instances[0].calls), 2)
         self.assertTrue(instances[0].calls[0][2])
         self.assertEqual(first, second)
@@ -78,9 +73,9 @@ class BERTScoreScorerReuseTestCase(unittest.TestCase):
         instances = []
 
         class FakeBERTScorer:
-            def __init__(self, lang, nthreads):
+            def __init__(self, lang):
                 if instances and instances[-1]() is not None:
-                    raise AssertionError('Previous model is still alive')
+                    raise AssertionError("Previous model is still alive")
                 self.lang = lang
                 instances.append(weakref.ref(self))
 
@@ -88,17 +83,15 @@ class BERTScoreScorerReuseTestCase(unittest.TestCase):
                 scores = np.array([0.5])
                 return scores, scores, scores
 
-        languages = iter(['en', 'de'])
+        languages = iter(["en", "de"])
         modules = {
-            'bert_score': SimpleNamespace(BERTScorer=FakeBERTScorer),
-            'langid': SimpleNamespace(
-                classify=lambda _: (next(languages), 1.0)
-            ),
+            "bert_score": SimpleNamespace(BERTScorer=FakeBERTScorer),
+            "langid": SimpleNamespace(classify=lambda _: (next(languages), 1.0)),
         }
 
         with patch.dict(sys.modules, modules):
-            BERTScoreScorer().score(['first'], [['first']])
-            BERTScoreScorer().score(['zweite'], [['zweite']])
+            BERTScoreScorer().score(["first"], [["first"]])
+            BERTScoreScorer().score(["zweite"], [["zweite"]])
 
         self.assertIsNone(instances[0]())
         self.assertIsNotNone(instances[1]())
@@ -109,7 +102,7 @@ class BERTScoreScorerReuseTestCase(unittest.TestCase):
         instances = []
 
         class FakeBERTScorer:
-            def __init__(self, lang, nthreads):
+            def __init__(self, lang):
                 self.lang = lang
                 instances.append(self)
                 constructor_started.set()
@@ -120,20 +113,18 @@ class BERTScoreScorerReuseTestCase(unittest.TestCase):
                 return scores, scores, scores
 
         modules = {
-            'bert_score': SimpleNamespace(BERTScorer=FakeBERTScorer),
-            'langid': SimpleNamespace(classify=lambda _: ('en', 1.0)),
+            "bert_score": SimpleNamespace(BERTScorer=FakeBERTScorer),
+            "langid": SimpleNamespace(classify=lambda _: ("en", 1.0)),
         }
 
         with patch.dict(sys.modules, modules):
             with ThreadPoolExecutor(max_workers=1) as executor:
-                first = executor.submit(
-                    BERTScoreScorer().score, ['first'], [['first']]
-                )
+                first = executor.submit(BERTScoreScorer().score, ["first"], [["first"]])
                 self.assertTrue(constructor_started.wait(timeout=1))
                 timer = Timer(0.5, release_constructor.set)
                 timer.start()
                 try:
-                    BERTScoreScorer().score(['second'], [['second']])
+                    BERTScoreScorer().score(["second"], [["second"]])
                     first.result(timeout=2)
                 finally:
                     release_constructor.set()

--- a/tests/scorers/test_bert_score.py
+++ b/tests/scorers/test_bert_score.py
@@ -7,13 +7,19 @@
 
 import sys
 import unittest
+import weakref
+from concurrent.futures import ThreadPoolExecutor
+from threading import Event, Timer
 from types import SimpleNamespace
 from unittest.mock import patch
 
 import numpy as np
 
 from . import VizSeqScorerTestCase
-from vizseq.scorers.bert_score import BERTScoreScorer
+from vizseq.scorers.bert_score import (
+    BERTScoreScorer,
+    _clear_bert_scorer_cache,
+)
 
 
 class BERTScoreScorerTestCase(VizSeqScorerTestCase):
@@ -22,6 +28,12 @@ class BERTScoreScorerTestCase(VizSeqScorerTestCase):
 
 
 class BERTScoreScorerReuseTestCase(unittest.TestCase):
+    def setUp(self):
+        _clear_bert_scorer_cache()
+
+    def tearDown(self):
+        _clear_bert_scorer_cache()
+
     def test_reuses_model_for_repeated_scores_in_same_language(self):
         instances = []
 
@@ -41,15 +53,18 @@ class BERTScoreScorerReuseTestCase(unittest.TestCase):
             'bert_score': SimpleNamespace(BERTScorer=FakeBERTScorer),
             'langid': SimpleNamespace(classify=lambda _: ('en', 1.0)),
         }
-        scorer = BERTScoreScorer(
+        first_scorer = BERTScoreScorer(
+            corpus_level=True, sent_level=True, n_workers=1, verbose=True
+        )
+        second_scorer = BERTScoreScorer(
             corpus_level=True, sent_level=True, n_workers=1, verbose=True
         )
         hypothesis = ['first hypothesis', 'second hypothesis']
         references = [['first reference', 'second reference']]
 
         with patch.dict(sys.modules, modules):
-            first = scorer.score(hypothesis, references)
-            second = scorer.score(hypothesis, references)
+            first = first_scorer.score(hypothesis, references)
+            second = second_scorer.score(hypothesis, references)
 
         self.assertEqual(len(instances), 1)
         self.assertEqual(instances[0].nthreads, 1)
@@ -58,3 +73,70 @@ class BERTScoreScorerReuseTestCase(unittest.TestCase):
         self.assertEqual(first, second)
         self.assertEqual(first.corpus_score, 0.5)
         self.assertEqual(first.sent_scores, [0.25, 0.75])
+
+    def test_releases_cached_model_before_loading_replacement(self):
+        instances = []
+
+        class FakeBERTScorer:
+            def __init__(self, lang, nthreads):
+                if instances and instances[-1]() is not None:
+                    raise AssertionError('Previous model is still alive')
+                self.lang = lang
+                instances.append(weakref.ref(self))
+
+            def score(self, hypothesis, references, verbose=False):
+                scores = np.array([0.5])
+                return scores, scores, scores
+
+        languages = iter(['en', 'de'])
+        modules = {
+            'bert_score': SimpleNamespace(BERTScorer=FakeBERTScorer),
+            'langid': SimpleNamespace(
+                classify=lambda _: (next(languages), 1.0)
+            ),
+        }
+
+        with patch.dict(sys.modules, modules):
+            BERTScoreScorer().score(['first'], [['first']])
+            BERTScoreScorer().score(['zweite'], [['zweite']])
+
+        self.assertIsNone(instances[0]())
+        self.assertIsNotNone(instances[1]())
+
+    def test_initializes_model_once_for_concurrent_cache_misses(self):
+        constructor_started = Event()
+        release_constructor = Event()
+        instances = []
+
+        class FakeBERTScorer:
+            def __init__(self, lang, nthreads):
+                self.lang = lang
+                instances.append(self)
+                constructor_started.set()
+                release_constructor.wait(timeout=2)
+
+            def score(self, hypothesis, references, verbose=False):
+                scores = np.array([0.5])
+                return scores, scores, scores
+
+        modules = {
+            'bert_score': SimpleNamespace(BERTScorer=FakeBERTScorer),
+            'langid': SimpleNamespace(classify=lambda _: ('en', 1.0)),
+        }
+
+        with patch.dict(sys.modules, modules):
+            with ThreadPoolExecutor(max_workers=1) as executor:
+                first = executor.submit(
+                    BERTScoreScorer().score, ['first'], [['first']]
+                )
+                self.assertTrue(constructor_started.wait(timeout=1))
+                timer = Timer(0.5, release_constructor.set)
+                timer.start()
+                try:
+                    BERTScoreScorer().score(['second'], [['second']])
+                    first.result(timeout=2)
+                finally:
+                    release_constructor.set()
+                    timer.join()
+
+        self.assertEqual(len(instances), 1)

--- a/tests/scorers/test_bert_score.py
+++ b/tests/scorers/test_bert_score.py
@@ -5,6 +5,13 @@
 # LICENSE file in the root directory of this source tree.
 #
 
+import sys
+import unittest
+from types import SimpleNamespace
+from unittest.mock import patch
+
+import numpy as np
+
 from . import VizSeqScorerTestCase
 from vizseq.scorers.bert_score import BERTScoreScorer
 
@@ -12,3 +19,42 @@ from vizseq.scorers.bert_score import BERTScoreScorer
 class BERTScoreScorerTestCase(VizSeqScorerTestCase):
     def test(self):
         return self._test_embedding_based(BERTScoreScorer)
+
+
+class BERTScoreScorerReuseTestCase(unittest.TestCase):
+    def test_reuses_model_for_repeated_scores_in_same_language(self):
+        instances = []
+
+        class FakeBERTScorer:
+            def __init__(self, lang, nthreads):
+                self.lang = lang
+                self.nthreads = nthreads
+                self.calls = []
+                instances.append(self)
+
+            def score(self, hypothesis, references, verbose=False):
+                self.calls.append((hypothesis, references, verbose))
+                scores = np.array([0.25, 0.75])
+                return scores, scores, scores
+
+        modules = {
+            'bert_score': SimpleNamespace(BERTScorer=FakeBERTScorer),
+            'langid': SimpleNamespace(classify=lambda _: ('en', 1.0)),
+        }
+        scorer = BERTScoreScorer(
+            corpus_level=True, sent_level=True, n_workers=1, verbose=True
+        )
+        hypothesis = ['first hypothesis', 'second hypothesis']
+        references = [['first reference', 'second reference']]
+
+        with patch.dict(sys.modules, modules):
+            first = scorer.score(hypothesis, references)
+            second = scorer.score(hypothesis, references)
+
+        self.assertEqual(len(instances), 1)
+        self.assertEqual(instances[0].nthreads, 1)
+        self.assertEqual(len(instances[0].calls), 2)
+        self.assertTrue(instances[0].calls[0][2])
+        self.assertEqual(first, second)
+        self.assertEqual(first.corpus_score, 0.5)
+        self.assertEqual(first.sent_scores, [0.25, 0.75])

--- a/vizseq/scorers/bert_score.py
+++ b/vizseq/scorers/bert_score.py
@@ -8,20 +8,54 @@
 from vizseq.scorers import register_scorer, VizSeqScorer, VizSeqScore
 
 import numpy as np
-from typing import List, Optional
+from typing import Any, List, Optional, Tuple
+
+
+# A BERTScorer holds a large transformer model (RoBERTa-large for English),
+# whose loading dominates the cost of scoring. Callers build a throwaway
+# scorer object per metric per model on every call (see vizseq.ipynb.core and
+# vizseq._view.data_view, which re-score on every page render and sort), so
+# the cache has to outlive the scorer instance to be of any use. One entry is
+# enough, and keeps us from pinning several models in memory at once: a given
+# view scores all of its models against the same references, so the key only
+# changes when the dataset or the worker count does.
+_cached_bert_scorer_key: Optional[Tuple[type, str, int]] = None
+_cached_bert_scorer: Optional[Any] = None
+
+
+def _get_bert_scorer(bs, lang: str, nthreads: int):
+    global _cached_bert_scorer_key, _cached_bert_scorer
+    # The class is part of the key: a cached instance is only valid for the
+    # constructor that produced it, so a swapped-out bert_score module (a
+    # reload, or a test double) gets its own scorer rather than a stale one.
+    key = (bs.BERTScorer, lang, nthreads)
+    if _cached_bert_scorer is None or _cached_bert_scorer_key != key:
+        _cached_bert_scorer = bs.BERTScorer(lang=lang, nthreads=nthreads)
+        _cached_bert_scorer_key = key
+    return _cached_bert_scorer
+
+
+def _clear_bert_scorer_cache() -> None:
+    global _cached_bert_scorer_key, _cached_bert_scorer
+    _cached_bert_scorer_key, _cached_bert_scorer = None, None
 
 
 @register_scorer('bert_score', 'BERTScore')
 class BERTScoreScorer(VizSeqScorer):
-    def __init__(self, *args, **kwargs):
-        super().__init__(*args, **kwargs)
-        self._bert_scorer = None
-
     def score(
             self, hypothesis: List[str], references: List[List[str]],
             tags: Optional[List[List[str]]] = None
     ) -> VizSeqScore:
         corpus_score, sent_scores, group_scores = None, None, None
+
+        # BERTScorer.score() has no length check of its own (the functional
+        # bert_score.score() it replaced did), and silently mis-aligns
+        # hypotheses and references when the two disagree.
+        n_samples = len(hypothesis)
+        if not all(len(r) == n_samples for r in references):
+            raise ValueError(
+                f'All reference lists must have the same length as hypothesis ({n_samples})'
+            )
 
         try:
             import bert_score as bs
@@ -37,12 +71,9 @@ class BERTScoreScorer(VizSeqScorer):
 
         lang = langid.classify(references[0][0])[0]
 
-        if self._bert_scorer is None or self._bert_scorer.lang != lang:
-            self._bert_scorer = bs.BERTScorer(
-                lang=lang, nthreads=self.n_workers
-            )
+        bert_scorer = _get_bert_scorer(bs, lang, self.n_workers)
 
-        sent_scores = self._bert_scorer.score(
+        sent_scores = bert_scorer.score(
             hypothesis, references[0], verbose=self.verbose
         )[2].tolist()
 

--- a/vizseq/scorers/bert_score.py
+++ b/vizseq/scorers/bert_score.py
@@ -8,6 +8,7 @@
 from vizseq.scorers import register_scorer, VizSeqScorer, VizSeqScore
 
 import numpy as np
+from threading import Lock
 from typing import Any, List, Optional, Tuple
 
 
@@ -21,6 +22,7 @@ from typing import Any, List, Optional, Tuple
 # changes when the dataset or the worker count does.
 _cached_bert_scorer_key: Optional[Tuple[type, str, int]] = None
 _cached_bert_scorer: Optional[Any] = None
+_bert_scorer_cache_lock = Lock()
 
 
 def _get_bert_scorer(bs, lang: str, nthreads: int):
@@ -29,15 +31,21 @@ def _get_bert_scorer(bs, lang: str, nthreads: int):
     # constructor that produced it, so a swapped-out bert_score module (a
     # reload, or a test double) gets its own scorer rather than a stale one.
     key = (bs.BERTScorer, lang, nthreads)
-    if _cached_bert_scorer is None or _cached_bert_scorer_key != key:
-        _cached_bert_scorer = bs.BERTScorer(lang=lang, nthreads=nthreads)
-        _cached_bert_scorer_key = key
-    return _cached_bert_scorer
+    with _bert_scorer_cache_lock:
+        if _cached_bert_scorer is None or _cached_bert_scorer_key != key:
+            # Drop the old model before loading its replacement so a language
+            # or worker-count change does not require both models to fit in
+            # memory at once.
+            _cached_bert_scorer_key, _cached_bert_scorer = None, None
+            scorer = bs.BERTScorer(lang=lang, nthreads=nthreads)
+            _cached_bert_scorer_key, _cached_bert_scorer = key, scorer
+        return _cached_bert_scorer
 
 
 def _clear_bert_scorer_cache() -> None:
     global _cached_bert_scorer_key, _cached_bert_scorer
-    _cached_bert_scorer_key, _cached_bert_scorer = None, None
+    with _bert_scorer_cache_lock:
+        _cached_bert_scorer_key, _cached_bert_scorer = None, None
 
 
 @register_scorer('bert_score', 'BERTScore')

--- a/vizseq/scorers/bert_score.py
+++ b/vizseq/scorers/bert_score.py
@@ -19,25 +19,31 @@ from typing import Any, List, Optional, Tuple
 # the cache has to outlive the scorer instance to be of any use. One entry is
 # enough, and keeps us from pinning several models in memory at once: a given
 # view scores all of its models against the same references, so the key only
-# changes when the dataset or the worker count does.
-_cached_bert_scorer_key: Optional[Tuple[type, str, int]] = None
+# changes when the dataset's language does.
+#
+# n_workers is deliberately neither passed through nor part of the key.
+# bert-score's nthreads only sizes the pool in get_idf_dict(), reachable just
+# from compute_idf(), which needs idf=True; we score with the default
+# idf=False, so it cannot affect a score. Keying on it would evict and reload
+# RoBERTa-large for byte-identical output. If idf support is ever added,
+# nthreads has to go back into the key *and* the constructor together.
+_cached_bert_scorer_key: Optional[Tuple[type, str]] = None
 _cached_bert_scorer: Optional[Any] = None
 _bert_scorer_cache_lock = Lock()
 
 
-def _get_bert_scorer(bs, lang: str, nthreads: int):
+def _get_bert_scorer(bs, lang: str):
     global _cached_bert_scorer_key, _cached_bert_scorer
     # The class is part of the key: a cached instance is only valid for the
     # constructor that produced it, so a swapped-out bert_score module (a
     # reload, or a test double) gets its own scorer rather than a stale one.
-    key = (bs.BERTScorer, lang, nthreads)
+    key = (bs.BERTScorer, lang)
     with _bert_scorer_cache_lock:
         if _cached_bert_scorer is None or _cached_bert_scorer_key != key:
             # Drop the old model before loading its replacement so a language
-            # or worker-count change does not require both models to fit in
-            # memory at once.
+            # change does not require both models to fit in memory at once.
             _cached_bert_scorer_key, _cached_bert_scorer = None, None
-            scorer = bs.BERTScorer(lang=lang, nthreads=nthreads)
+            scorer = bs.BERTScorer(lang=lang)
             _cached_bert_scorer_key, _cached_bert_scorer = key, scorer
         return _cached_bert_scorer
 
@@ -92,7 +98,7 @@ class BERTScoreScorer(VizSeqScorer):
 
         lang = langid.classify(references[0][0])[0]
 
-        bert_scorer = _get_bert_scorer(bs, lang, self.n_workers)
+        bert_scorer = _get_bert_scorer(bs, lang)
 
         sent_scores = bert_scorer.score(
             hypothesis, references[0], verbose=self.verbose

--- a/vizseq/scorers/bert_score.py
+++ b/vizseq/scorers/bert_score.py
@@ -13,6 +13,10 @@ from typing import List, Optional
 
 @register_scorer('bert_score', 'BERTScore')
 class BERTScoreScorer(VizSeqScorer):
+    def __init__(self, *args, **kwargs):
+        super().__init__(*args, **kwargs)
+        self._bert_scorer = None
+
     def score(
             self, hypothesis: List[str], references: List[List[str]],
             tags: Optional[List[List[str]]] = None
@@ -33,9 +37,13 @@ class BERTScoreScorer(VizSeqScorer):
 
         lang = langid.classify(references[0][0])[0]
 
-        sent_scores = bs.score(
-            hypothesis, references[0], nthreads=self.n_workers, lang=lang,
-            verbose=self.verbose
+        if self._bert_scorer is None or self._bert_scorer.lang != lang:
+            self._bert_scorer = bs.BERTScorer(
+                lang=lang, nthreads=self.n_workers
+            )
+
+        sent_scores = self._bert_scorer.score(
+            hypothesis, references[0], verbose=self.verbose
         )[2].tolist()
 
         if self.corpus_level:

--- a/vizseq/scorers/bert_score.py
+++ b/vizseq/scorers/bert_score.py
@@ -64,6 +64,19 @@ class BERTScoreScorer(VizSeqScorer):
             raise ValueError(
                 f'All reference lists must have the same length as hypothesis ({n_samples})'
             )
+        if n_samples == 0:
+            # Nothing to score, and no text to detect a language from. Most
+            # scorers return nan for an empty corpus rather than raising, so
+            # do the same instead of falling through to references[0][0].
+            return VizSeqScore.make(
+                corpus_score=np.nan if self.corpus_level else None,
+                sent_scores=[],
+                group_scores={} if tags is not None else None,
+            )
+        if not references:
+            # The length check above is vacuous when there is nothing to
+            # iterate over, and scoring reads references[0] below.
+            raise ValueError('At least one reference list is required')
 
         try:
             import bert_score as bs


### PR DESCRIPTION
## Summary
- replace the functional `bert_score.score` call with a lazily initialized `BERTScorer`
- cache the loaded model at module level, keyed on `(BERTScorer class, language)`, so it is reused across scoring calls
- require `bert-score>=0.3.1`, where the object-oriented API was introduced
- restore the hypothesis/reference length check that the functional API used to provide, and handle the degenerate inputs it does not cover
- add regression tests for model reuse, cache eviction, and concurrent cache misses

### Why the cache is module-level

An earlier revision of this PR cached on the scorer instance (`self._bert_scorer`). That never fires in practice: every caller in vizseq builds a throwaway `BERTScoreScorer` per metric per model and discards it — `vizseq/ipynb/core.py`, `vizseq/_view/data_view.py` (twice, so the web UI reloads the model on every page render *and* every sort), and `vizseq/_view/mem_cached_data_getters.py`. `self._bert_scorer` was therefore always `None` on entry and the model reloaded every time. Moving the cache to module scope makes it survive those throwaway instances.

The cache holds a single entry rather than a dict, so we never pin several RoBERTa-large models in memory at once; a given view scores all of its models against the same references, so the key only changes when the dataset's language does. The `BERTScorer` class is part of the key because a cached instance is only valid for the constructor that produced it.

### Why `nthreads` is not in the key

An earlier revision keyed on `(BERTScorer class, language, nthreads)` and passed `nthreads=self.n_workers` to the constructor. `nthreads` cannot affect a score: `bert-score` reads it in exactly one place, `get_idf_dict()`, reached only from `BERTScorer.compute_idf()`, which requires `idf=True`. This scorer uses the default `idf=False` and never passes `idf_sents`, so `compute_idf()` is never called; `nthreads` is also absent from `BERTScorer.hash`. The functional `bert_score.score()` this replaces carried the same dead parameter, guarded by `if not idf:`.

Keying on it meant two scorers differing only in `n_workers` would evict and reload RoBERTa-large for byte-identical output — the exact cost this PR exists to remove. It is now dropped from the key *and* the constructor together, so the key stays equivalent to the constructor arguments; splitting them would leave the cache serving whichever `nthreads` won the first call. `n_workers` is consequently unused by this scorer, which is accurate — it never took the `_score_sentences_multiprocess` path.

### Input validation

`BERTScorer.score()` has no length validation, while the functional `bert_score.score()` it replaces opened with `assert len(cands) == len(refs)`. Without it a mismatch propagates into `bert_cos_score_idf`, which slices hypotheses and references at shared offsets and silently mis-aligns them. This is reachable whenever `pred_*.txt` and `ref_*.txt` differ in line count: they come from two separate `VizSeqDataSources`, and `VizSeqScorer._batch`'s existing guard is never reached because this scorer does not use the multiprocess path. The check now raises `ValueError` with the same message shape as `_batch`, before any model is constructed.

A length check alone is vacuous when there is nothing to iterate over, and this scorer dereferences `references[0][0]` to detect the language. Two inputs satisfied the check and then raised `IndexError`:

- **empty corpus** (`hypothesis=[]` with `references=[[]]` or `[]`) — now returns `nan`, matching `cider`, `gleu`, `meteor`, `nist`, `ribes`, `rouge_*`, `ter` and `wer_*`, which all return `VizSeqScore(corpus_score=nan, sent_scores=[], group_scores=None)` for an empty corpus rather than raising. No model is loaded on this path.
- **no reference lists at all** alongside a non-empty hypothesis (`references=[]`) — now raises `ValueError`, since there is nothing to score against.

## Test plan
- `.venv/bin/python -m pytest tests/scorers/test_bert_score.py -k Reuse -q` (3 passed)
- `.venv/bin/python -m pytest tests -q --ignore=tests/scorers/test_laser.py --ignore=tests/test_embedding_based_scorers.py` (47 passed, 6 subtests passed; `BERTScoreScorerTestCase::test` fails locally only because the optional Torch/Transformers dependencies are not installed, same as on `main`)
- `.venv/bin/python -m flake8 vizseq tests`

The heavyweight BERTScore integration test was not run locally for the same reason; the embeddings CI job covers it.

Compatibility of the version floor was checked against the published wheels: 0.3.0 ships no `scorer.py` at all, while 0.3.1 and 0.3.13 (the top of the `<1.0.0` range) both expose `BERTScorer(lang=...)` and `score(cands, refs, verbose=...)` with the same defaults as the functional API it replaces (`batch_size=64`, `idf=False`, `num_layers=None`, `rescale_with_baseline=False`), and `[..., 2]` is F1 on both paths.

Cache behaviour was checked with a stubbed `bert_score` module: five consecutive calls at `n_workers = 1, 2, 4, None, 2` now construct one model instead of four.

### Remaining test coverage gap

The input-validation branches (length mismatch, empty corpus, missing reference list) are verified manually but not yet covered by a committed test. They were checked with a stubbed `bert_score` whose constructor raises if called, confirming all five cases behave as described above and that the empty-corpus path loads nothing.

### Follow-up not addressed here

The cached model is pinned for the lifetime of the process and the only way to release it is the private `_clear_bert_scorer_cache()`. A public equivalent would help long-lived servers and GPU memory.

Fixes #28
