### PR TITLE
Prevent notebook CSS from leaking into Jupyter

### DIFF
--- a/tests/ipynb/test_core.py
+++ b/tests/ipynb/test_core.py
@@ -5,12 +5,118 @@
 # LICENSE file in the root directory of this source tree.
 #
 
+from html.parser import HTMLParser
+
 from . import VizSeqIpynbTestCase
-from vizseq.ipynb.core import (view_stats, view_examples, view_n_grams,
+from vizseq.ipynb.core import (env, view_stats, view_examples, view_n_grams,
                                view_scores)
+from vizseq._visualizers import SPAN_HIGHTLIGHT_JS
+
+
+class ExportAttributeParser(HTMLParser):
+    def __init__(self):
+        super().__init__()
+        self.button_targets = []
+        self.export_names = []
+        self.handlers = []
+
+    def handle_starttag(self, tag, attrs):
+        attrs = dict(attrs)
+        if tag == 'button':
+            self.button_targets.append(attrs.get('data-vizseq-target'))
+            self.handlers.append(attrs.get('onclick'))
+        elif tag == 'span' and 'data-vizseq-export' in attrs:
+            self.export_names.append(attrs['data-vizseq-export'])
 
 
 class VizSeqIpynbCoreTestCase(VizSeqIpynbTestCase):
+    @staticmethod
+    def _score_template_context(metric='bleu'):
+        return {
+            'metrics_and_names': [[metric, 'Metric']],
+            'models': ['model'],
+            'tag_set': ['tag'],
+            'corpus_scores': {metric: {'model': 42.0}},
+            'group_scores': {metric: {'tag': {'model': 40.0}}},
+            'corpus_and_group_score_latex': {metric: 'latex export'},
+            'corpus_and_group_score_csv': {metric: 'csv export'},
+        }
+
+    def test_templates_do_not_load_global_stylesheets(self):
+        templates = {
+            'ipynb_stats.html': ({
+                'stats': {
+                    'n_examples': 1,
+                    'n_src_tokens': {'source': 2},
+                    'n_src_chars': {'source': 12},
+                    'n_ref_tokens': {'reference': 2},
+                    'n_ref_chars': {'reference': 15},
+                },
+                'enum_src_names_and_types': [[0, 'source', 'Text']],
+                'enum_ref_names': [[0, 'reference']],
+            }, 'Source source'),
+            'ipynb_view.html': ({
+                'span_highlight_js': SPAN_HIGHTLIGHT_JS,
+                'cur_idx': [0],
+                'n_cur_samples': 1,
+                'n_samples': 1,
+                'total_examples': 1,
+                'enum_src_names_and_types': [[0, 'source', 'text']],
+                'src': [['example source']],
+                'google_translation': [],
+                'enum_ref_names': [[0, 'reference']],
+                'ref': [['example reference']],
+                'enum_models': [[0, 'model']],
+                'hypo': {'model': ['example hypothesis']},
+                'enum_metrics': [],
+                'sent_scores': [],
+            }, 'example source'),
+            'ipynb_scores.html': (
+                self._score_template_context(),
+                'data-vizseq-export="csv_bleu"',
+            ),
+            'ipynb_n_grams.html': ({
+                'n': [1],
+                'n_grams': {1: [('example n-gram', 1)]},
+            }, 'example n-gram'),
+        }
+
+        for template_name, (context, rendered_content) in templates.items():
+            with self.subTest(template=template_name):
+                html = env.get_template(template_name).render(**context)
+                self.assertIn('class="vizseq-output"', html)
+                self.assertIn('.vizseq-output .table', html)
+                self.assertIn('background-color: #fff', html)
+                self.assertIn(rendered_content, html)
+                self.assertNotIn('bootstrap.min.css', html)
+                self.assertNotIn('<script src=', html)
+                self.assertNotIn('<body', html.lower())
+                self.assertNotRegex(html, r'(?m)^\s*body\s*\{')
+
+        scores_html = env.get_template('ipynb_scores.html').render(
+            **templates['ipynb_scores.html'][0]
+        )
+        self.assertIn("this.closest('.vizseq-output')", scores_html)
+        self.assertIn('.vizseq-output .btn-sm', scores_html)
+        self.assertIn('if (source)', scores_html)
+        self.assertNotIn('id="csv_bleu"', scores_html)
+        self.assertNotIn('<script>', scores_html)
+
+    def test_score_export_names_are_not_interpolated_into_javascript(self):
+        metric = 'o\'brien"]'
+        html = env.get_template('ipynb_scores.html').render(
+            **self._score_template_context(metric)
+        )
+        parser = ExportAttributeParser()
+        parser.feed(html)
+
+        expected = {f'csv_{metric}', f'latex_{metric}'}
+        self.assertEqual(set(parser.button_targets), expected)
+        self.assertEqual(set(parser.export_names), expected)
+        for handler in parser.handlers:
+            self.assertNotIn(metric, handler)
+            self.assertIn('this.dataset.vizseqTarget', handler)
+
     def test_view_stats(self):
         _ = view_stats(self.source, self.references)
 

--- a/vizseq/_templates/ipynb_n_grams.html
+++ b/vizseq/_templates/ipynb_n_grams.html
@@ -1,18 +1,5 @@
-<!DOCTYPE html>
-<html lang="en">
-<head>
-    <link rel="stylesheet" href="https://stackpath.bootstrapcdn.com/bootstrap/4.2.1/css/bootstrap.min.css"
-          integrity="sha384-GJzZqFGwb1QTTN6wy59ffF1BuGJpLSa9DkKMp0DgiMDm4iYMj70gZWKYbI706tWS" crossorigin="anonymous">
-    <script src="https://kit.fontawesome.com/3c563f9647.js"></script>
-
-    <style>
-        body {
-            padding-top: 60px; /* 60px to make the container go all the way to the bottom of the topbar */
-        }
-    </style>
-</head>
-
-<body>
+{% include 'ipynb_styles.html' %}
+<div class="vizseq-output">
 
 
 <div class="container">
@@ -35,14 +22,4 @@
 </div>
 
 
-<script src="https://code.jquery.com/jquery-3.3.1.slim.min.js"
-        integrity="sha384-q8i/X+965DzO0rT7abK41JStQIAqVgRVzpbzo5smXKp4YfRvH+8abtTE1Pi6jizo" crossorigin="anonymous">
-</script>
-<script src="https://cdnjs.cloudflare.com/ajax/libs/popper.js/1.14.6/umd/popper.min.js"
-        integrity="sha384-wHAiFfRlMFy6i5SRaxvfOCifBUQy1xHdJ/yoi7FRNXMRBu5WHdZYu1hA6ZOblgut" crossorigin="anonymous">
-</script>
-<script src="https://stackpath.bootstrapcdn.com/bootstrap/4.2.1/js/bootstrap.min.js"
-        integrity="sha384-B0UglyR+jN6CkvvICOB2joaf5I4l3gm9GU6Hc1og6Ls7i6U/mkkaduKaBhlAXv9k" crossorigin="anonymous">
-</script>
-</body>
-</html>
+</div>

--- a/vizseq/_templates/ipynb_scores.html
+++ b/vizseq/_templates/ipynb_scores.html
@@ -1,22 +1,30 @@
-<!DOCTYPE html>
-<html lang="en">
-<head>
-    <link rel="stylesheet" href="https://stackpath.bootstrapcdn.com/bootstrap/4.2.1/css/bootstrap.min.css"
-          integrity="sha384-GJzZqFGwb1QTTN6wy59ffF1BuGJpLSa9DkKMp0DgiMDm4iYMj70gZWKYbI706tWS" crossorigin="anonymous">
+{% include 'ipynb_styles.html' %}
+<div class="vizseq-output">
 
-    <style>
-        body {
-            padding-top: 60px; /* 60px to make the container go all the way to the bottom of the topbar */
-        }
-    </style>
-</head>
-
-<body>
-
-{% from 'macros.html' import visualize_dict, copy_to_clipboard %}
-
-{{ visualize_dict() }}
-{{ copy_to_clipboard() }}
+{% macro copy_button(label, export_name) -%}
+<button type="button" class="btn btn-secondary btn-sm"
+        title="Copy to clipboard"
+        data-vizseq-target="{{ export_name }}"
+        onclick="
+            const root = this.closest('.vizseq-output');
+            const source = root &amp;&amp; Array.from(
+                root.querySelectorAll('[data-vizseq-export]')
+            ).find(
+                element =&gt; element.dataset.vizseqExport ===
+                    this.dataset.vizseqTarget
+            );
+            if (source) {
+                const temp = document.createElement('textarea');
+                temp.value = source.textContent;
+                temp.style.position = 'fixed';
+                temp.style.opacity = '0';
+                document.body.appendChild(temp);
+                temp.select();
+                document.execCommand('copy');
+                temp.remove();
+            }
+        ">{{ label }}</button>
+{%- endmacro %}
 
 {% for s, n in metrics_and_names %}
 <div class="container-fluid">
@@ -28,12 +36,8 @@
                 <thead class="thead-light">
                 <tr>
                     <th scope="col">
-                        <button type="button" class="btn btn-secondary btn-sm" data-toggle="tooltip"
-                                data-placement="bottom" title="Copy to clipboard"
-                                onclick="copyToClipboard('#csv_{{ s }}')">CSV</button>
-                        <button type="button" class="btn btn-secondary btn-sm" data-toggle="tooltip"
-                                data-placement="bottom" title="Copy to clipboard"
-                                onclick="copyToClipboard('#latex_{{ s }}')">LaTeX</button>
+                        {{ copy_button('CSV', 'csv_' + s) }}
+                        {{ copy_button('LaTeX', 'latex_' + s) }}
                     </th>
                     {% for m in models %} <th scope="col" style="word-wrap: break-word">{{ m }}</th> {% endfor %}
                 </tr>
@@ -52,20 +56,9 @@
         </div>
     </div>
 
-    <span id="latex_{{ s }}" style="display:none">{{ corpus_and_group_score_latex[s] }}</span>
-    <span id="csv_{{ s }}" style="display:none">{{ corpus_and_group_score_csv[s] }}</span>
+    <span data-vizseq-export="latex_{{ s }}" style="display:none">{{ corpus_and_group_score_latex[s] }}</span>
+    <span data-vizseq-export="csv_{{ s }}" style="display:none">{{ corpus_and_group_score_csv[s] }}</span>
 </div>
 {% endfor %}
 
-<script src="https://code.jquery.com/jquery-3.3.1.slim.min.js"
-        integrity="sha384-q8i/X+965DzO0rT7abK41JStQIAqVgRVzpbzo5smXKp4YfRvH+8abtTE1Pi6jizo" crossorigin="anonymous">
-</script>
-<script src="https://cdnjs.cloudflare.com/ajax/libs/popper.js/1.14.6/umd/popper.min.js"
-        integrity="sha384-wHAiFfRlMFy6i5SRaxvfOCifBUQy1xHdJ/yoi7FRNXMRBu5WHdZYu1hA6ZOblgut" crossorigin="anonymous">
-</script>
-<script src="https://stackpath.bootstrapcdn.com/bootstrap/4.2.1/js/bootstrap.min.js"
-        integrity="sha384-B0UglyR+jN6CkvvICOB2joaf5I4l3gm9GU6Hc1og6Ls7i6U/mkkaduKaBhlAXv9k" crossorigin="anonymous">
-</script>
-
-</body>
-</html>
+</div>

--- a/vizseq/_templates/ipynb_stats.html
+++ b/vizseq/_templates/ipynb_stats.html
@@ -1,17 +1,5 @@
-<!DOCTYPE html>
-<html lang="en">
-<head>
-    <link rel="stylesheet" href="https://stackpath.bootstrapcdn.com/bootstrap/4.2.1/css/bootstrap.min.css"
-          integrity="sha384-GJzZqFGwb1QTTN6wy59ffF1BuGJpLSa9DkKMp0DgiMDm4iYMj70gZWKYbI706tWS" crossorigin="anonymous">
-
-    <style>
-        body {
-            padding-top: 60px; /* 60px to make the container go all the way to the bottom of the topbar */
-        }
-    </style>
-</head>
-
-<body>
+{% include 'ipynb_styles.html' %}
+<div class="vizseq-output">
 
 <div class="container-fluid">
     <div class="row">
@@ -49,15 +37,4 @@
     </div>
 </div>
 
-<script src="https://code.jquery.com/jquery-3.3.1.slim.min.js"
-        integrity="sha384-q8i/X+965DzO0rT7abK41JStQIAqVgRVzpbzo5smXKp4YfRvH+8abtTE1Pi6jizo" crossorigin="anonymous">
-</script>
-<script src="https://cdnjs.cloudflare.com/ajax/libs/popper.js/1.14.6/umd/popper.min.js"
-        integrity="sha384-wHAiFfRlMFy6i5SRaxvfOCifBUQy1xHdJ/yoi7FRNXMRBu5WHdZYu1hA6ZOblgut" crossorigin="anonymous">
-</script>
-<script src="https://stackpath.bootstrapcdn.com/bootstrap/4.2.1/js/bootstrap.min.js"
-        integrity="sha384-B0UglyR+jN6CkvvICOB2joaf5I4l3gm9GU6Hc1og6Ls7i6U/mkkaduKaBhlAXv9k" crossorigin="anonymous">
-</script>
-
-</body>
-</html>
+</div>

--- a/vizseq/_templates/ipynb_styles.html
+++ b/vizseq/_templates/ipynb_styles.html
@@ -1,0 +1,139 @@
+<style>
+    .vizseq-output {
+        background-color: #fff;
+        color: #212529;
+        font-family: -apple-system, BlinkMacSystemFont, "Segoe UI", Roboto,
+                     "Helvetica Neue", Arial, sans-serif;
+        width: 100%;
+    }
+
+    .vizseq-output *,
+    .vizseq-output *::before,
+    .vizseq-output *::after {
+        box-sizing: border-box;
+    }
+
+    .vizseq-output .container,
+    .vizseq-output .container-fluid {
+        margin-left: auto;
+        margin-right: auto;
+        padding-left: 15px;
+        padding-right: 15px;
+        width: 100%;
+    }
+
+    .vizseq-output .row {
+        display: flex;
+        flex-wrap: wrap;
+        margin-left: -15px;
+        margin-right: -15px;
+    }
+
+    .vizseq-output .col {
+        flex-basis: 0;
+        flex-grow: 1;
+        max-width: 100%;
+        min-width: 0;
+        padding-left: 15px;
+        padding-right: 15px;
+        position: relative;
+    }
+
+    .vizseq-output .card {
+        background-color: #fff;
+        border: 1px solid rgba(0, 0, 0, 0.125);
+        border-radius: 0.25rem;
+        min-width: 0;
+    }
+
+    .vizseq-output .card-header {
+        background-color: rgba(0, 0, 0, 0.03);
+        border-bottom: 1px solid rgba(0, 0, 0, 0.125);
+        padding: 0.75rem 1.25rem;
+    }
+
+    .vizseq-output .card-body {
+        padding: 1.25rem;
+    }
+
+    .vizseq-output .table {
+        border-collapse: collapse;
+        color: #212529;
+        margin-bottom: 1rem;
+        width: 100%;
+    }
+
+    .vizseq-output .table th,
+    .vizseq-output .table td {
+        border-top: 1px solid #dee2e6;
+        padding: 0.75rem;
+        vertical-align: top;
+    }
+
+    .vizseq-output .table-sm th,
+    .vizseq-output .table-sm td {
+        padding: 0.3rem;
+    }
+
+    .vizseq-output .table-bordered th,
+    .vizseq-output .table-bordered td {
+        border: 1px solid #dee2e6;
+    }
+
+    .vizseq-output .table-borderless th,
+    .vizseq-output .table-borderless td {
+        border: 0;
+    }
+
+    .vizseq-output .table-hover tbody tr:hover {
+        background-color: rgba(0, 0, 0, 0.075);
+    }
+
+    .vizseq-output .thead-light th {
+        background-color: #e9ecef;
+        border-color: #dee2e6;
+        color: #495057;
+    }
+
+    .vizseq-output .text-left {
+        text-align: left;
+    }
+
+    .vizseq-output .text-center {
+        text-align: center;
+    }
+
+    .vizseq-output .text-nowrap {
+        white-space: nowrap;
+    }
+
+    .vizseq-output .btn {
+        background-color: transparent;
+        border: 1px solid transparent;
+        border-radius: 0.2rem;
+        cursor: pointer;
+        display: inline-block;
+        font: inherit;
+        line-height: 1.5;
+        padding: 0.25rem 0.5rem;
+        text-align: center;
+    }
+
+    .vizseq-output .btn-secondary {
+        background-color: #6c757d;
+        border-color: #6c757d;
+        color: #fff;
+    }
+
+    .vizseq-output .btn-sm {
+        border-radius: 0.2rem;
+        font-size: 0.875rem;
+        line-height: 1.5;
+        padding: 0.25rem 0.5rem;
+    }
+
+    .vizseq-output img {
+        height: auto;
+        max-width: 100%;
+    }
+</style>

--- a/vizseq/_templates/ipynb_view.html
+++ b/vizseq/_templates/ipynb_view.html
@@ -1,17 +1,5 @@
-<!DOCTYPE html>
-<html lang="en">
-<head>
-    <link rel="stylesheet" href="https://stackpath.bootstrapcdn.com/bootstrap/4.2.1/css/bootstrap.min.css"
-          integrity="sha384-GJzZqFGwb1QTTN6wy59ffF1BuGJpLSa9DkKMp0DgiMDm4iYMj70gZWKYbI706tWS" crossorigin="anonymous">
-
-    <style>
-        body {
-            padding-top: 60px; /* 60px to make the container go all the way to the bottom of the topbar */
-        }
-    </style>
-</head>
-
-<body>
+{% include 'ipynb_styles.html' %}
+<div class="vizseq-output">
 
 {{ span_highlight_js }}
 
@@ -96,14 +84,4 @@
 <br>
 {% endfor %}
 
-<script src="https://code.jquery.com/jquery-3.3.1.slim.min.js"
-        integrity="sha384-q8i/X+965DzO0rT7abK41JStQIAqVgRVzpbzo5smXKp4YfRvH+8abtTE1Pi6jizo" crossorigin="anonymous">
-</script>
-<script src="https://cdnjs.cloudflare.com/ajax/libs/popper.js/1.14.6/umd/popper.min.js"
-        integrity="sha384-wHAiFfRlMFy6i5SRaxvfOCifBUQy1xHdJ/yoi7FRNXMRBu5WHdZYu1hA6ZOblgut" crossorigin="anonymous">
-</script>
-<script src="https://stackpath.bootstrapcdn.com/bootstrap/4.2.1/js/bootstrap.min.js"
-        integrity="sha384-B0UglyR+jN6CkvvICOB2joaf5I4l3gm9GU6Hc1og6Ls7i6U/mkkaduKaBhlAXv9k" crossorigin="anonymous">
-</script>
-</body>
-</html>
+</div>


### PR DESCRIPTION
## Motivation

VizSeq notebook views loaded Bootstrap into the parent notebook document and applied padding directly to `body`. This changed Jupyter's own layout after rendering `view_stats` or another VizSeq view.

This change:
- renders notebook output as an HTML fragment instead of a nested document
- replaces global Bootstrap styling with a shared stylesheet scoped under `.vizseq-output`
- removes unused global third-party scripts from notebook templates
- keeps score export buttons self-contained with browser-native DOM APIs
- adds regression coverage across all notebook templates

### Have you read the [Contributing Guidelines on pull requests](https://github.com/facebookresearch/vizseq/blob/main/CONTRIBUTING.md)?

Yes.

## Test Plan

- `.venv/bin/python -m pytest tests/ipynb/test_core.py -q` (9 passed, 4 subtests passed)
- `.venv/bin/python -m pytest -q --ignore=tests/scorers/test_bert_score.py --ignore=tests/scorers/test_laser.py` (45 passed, 10 subtests passed)
- `.venv/bin/python -m flake8 vizseq tests`
- `uv build --wheel` and verify `ipynb_styles.html` is packaged

The two excluded scorer tests require the optional `bert-score` and `laserembeddings` dependencies, which are not installed locally.

## Related Issues and PRs

Fixes #26