### PR TITLE
Add Windows support and CI coverage

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -15,7 +15,7 @@ jobs:
           python-version: "3.11"
       - run: pip install flake8
       - name: Run flake8
-        run: flake8 vizseq tests
+        run: flake8 vizseq tests get_example_data.py
 
   security:
     runs-on: ubuntu-latest
@@ -37,7 +37,7 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        os: [ubuntu-latest, macos-latest]
+        os: [ubuntu-latest, macos-latest, windows-latest]
         python-version: ["3.11", "3.12", "3.13"]
     runs-on: ${{ matrix.os }}
     timeout-minutes: 30
@@ -49,7 +49,8 @@ jobs:
       - name: Install VizSeq
         run: pip install -e .
       - name: Download example data
-        run: bash get_example_data.sh
+        run: python get_example_data.py
+      - run: python -m tests.test_get_example_data
       - run: python -m tests.test_n_gram_based_scorers
       - run: python -m tests.test_ipynb
       - run: python -m tests.test_web
@@ -65,7 +66,7 @@ jobs:
       - name: Install VizSeq with embedding dependencies
         run: pip install -e .[embeddings]
       - name: Download example data
-        run: bash get_example_data.sh
+        run: python get_example_data.py
       - run: python -m tests.test_embedding_based_scorers
 
   coverage:
@@ -92,7 +93,7 @@ jobs:
       - name: Install VizSeq
         run: pip install -e .[all] pytest pytest-cov
       - name: Download example data
-        run: bash get_example_data.sh
+        run: python get_example_data.py
       - name: Run tests with coverage
         run: pytest tests/ --cov=vizseq --cov-report=xml --cov-report=term-missing
       - uses: actions/upload-artifact@v4

--- a/README.md
+++ b/README.md
@@ -44,7 +44,7 @@ a normal Python package.
 ## Getting Started
 
 ### Installation
-VizSeq requires **Python 3.11+** and currently runs on **Unix/Linux** and **macOS/OS X**. It will support **Windows** as well in the future.
+VizSeq requires **Python 3.11+** and supports **Windows**, **Linux**, and **macOS**.
 
 You can install VizSeq from PyPI repository:
 ```bash
@@ -82,7 +82,7 @@ Download example data:
 ```bash
 $ git clone https://github.com/facebookresearch/vizseq
 $ cd vizseq
-$ bash get_example_data.sh
+$ python get_example_data.py
 ```
 Launch the web server:
 ```bash

--- a/examples/multilingual_machine_translation.ipynb
+++ b/examples/multilingual_machine_translation.ipynb
@@ -7,7 +7,7 @@
     "## 0. Download example data\n",
     "\n",
     "```bash\n",
-    "$ bash get_example_data.sh multilingual_translation_ted58_x_en_test\n",
+    "$ python get_example_data.py multilingual_translation_ted58_x_en_test\n",
     "```"
    ]
   },

--- a/examples/multimodal_machine_translation.ipynb
+++ b/examples/multimodal_machine_translation.ipynb
@@ -7,7 +7,7 @@
     "## 0.Download example data\n",
     "\n",
     "```bash\n",
-    "$ bash get_example_data.sh multimodal_translation_wmt16_en_de_test\n",
+    "$ python get_example_data.py multimodal_translation_wmt16_en_de_test\n",
     "```"
    ]
   },

--- a/examples/speech_translation.ipynb
+++ b/examples/speech_translation.ipynb
@@ -7,7 +7,7 @@
     "## 0.Download example data\n",
     "\n",
     "```bash\n",
-    "$ bash get_example_data.sh speech_translation_iwslt17_dev\n",
+    "$ python get_example_data.py speech_translation_iwslt17_dev\n",
     "```"
    ]
   },

--- a/get_example_data.py
+++ b/get_example_data.py
@@ -1,0 +1,85 @@
+#!/usr/bin/env python3
+# Copyright (c) Facebook, Inc. and its affiliates.
+
+"""Download and extract a VizSeq example dataset."""
+
+import argparse
+import re
+import shutil
+import tempfile
+import urllib.request
+import zipfile
+from pathlib import Path
+
+
+DEFAULT_TASK = 'translation_wmt14_en_de_test'
+DATA_URL = 'https://dl.fbaipublicfiles.com/vizseq/examples/data'
+TASK_NAME = re.compile(r'^[A-Za-z0-9_.-]+$')
+
+
+def _safe_extract(archive_path: Path, destination: Path) -> None:
+    destination = destination.resolve()
+    with zipfile.ZipFile(archive_path) as archive:
+        for member in archive.infolist():
+            member_path = Path(member.filename)
+            if member_path.is_absolute() or '..' in member_path.parts:
+                raise ValueError(
+                    f'Archive contains an unsafe path: {member.filename}'
+                )
+            target = (destination / member_path).resolve()
+            if not target.is_relative_to(destination):
+                raise ValueError(
+                    f'Archive contains an unsafe path: {member.filename}'
+                )
+        archive.extractall(destination)
+
+
+def download_example_data(
+        task: str = DEFAULT_TASK, data_root: Path = None,
+        data_url: str = DATA_URL,
+) -> Path:
+    if not TASK_NAME.fullmatch(task) or '..' in task:
+        raise ValueError(f'Invalid task name: {task}')
+
+    if data_root is None:
+        data_root = Path(__file__).resolve().parent / 'examples' / 'data'
+    else:
+        data_root = Path(data_root)
+    destination = data_root / task
+    if destination.is_dir():
+        print(f'Example data already exists at {destination}')
+        return destination
+
+    data_root.mkdir(parents=True, exist_ok=True)
+    url = f'{data_url.rstrip("/")}/{task}.zip'
+    with tempfile.TemporaryDirectory(
+            prefix='.vizseq-download-', dir=data_root
+    ) as temp_dir_name:
+        temp_dir = Path(temp_dir_name)
+        archive_path = temp_dir / f'{task}.zip'
+        extracted_root = temp_dir / 'extracted'
+        extracted_root.mkdir()
+
+        print(f'Downloading {url}')
+        with urllib.request.urlopen(url) as response, archive_path.open('wb') as output:
+            shutil.copyfileobj(response, output)
+        _safe_extract(archive_path, extracted_root)
+
+        extracted_task = extracted_root / task
+        if not extracted_task.is_dir():
+            raise ValueError(f'Archive does not contain the expected {task} directory')
+        shutil.move(str(extracted_task), destination)
+
+    print(f'Example data extracted to {destination}')
+    return destination
+
+
+def main() -> None:
+    parser = argparse.ArgumentParser(description=__doc__)
+    parser.add_argument('task', nargs='?', default=DEFAULT_TASK)
+    args = parser.parse_args()
+    download_example_data(args.task)
+
+
+if __name__ == '__main__':
+    main()

--- a/get_example_data.py
+++ b/get_example_data.py
@@ -10,6 +10,7 @@ import tempfile
 import urllib.request
 import zipfile
 from pathlib import Path
+from typing import Optional
 
 
 DEFAULT_TASK = 'translation_wmt14_en_de_test'
@@ -35,10 +36,14 @@ def _safe_extract(archive_path: Path, destination: Path) -> None:
 
 
 def download_example_data(
-        task: str = DEFAULT_TASK, data_root: Path = None,
+        task: str = DEFAULT_TASK, data_root: Optional[Path] = None,
         data_url: str = DATA_URL,
 ) -> Path:
-    if not TASK_NAME.fullmatch(task) or '..' in task:
+    if (
+            not TASK_NAME.fullmatch(task)
+            or task in {'.', '..'}
+            or Path(task).name != task
+    ):
         raise ValueError(f'Invalid task name: {task}')
 
     if data_root is None:

--- a/get_example_data.py
+++ b/get_example_data.py
@@ -7,6 +7,7 @@ import argparse
 import re
 import shutil
 import tempfile
+import urllib.error
 import urllib.request
 import zipfile
 from pathlib import Path
@@ -66,8 +67,18 @@ def download_example_data(
         extracted_root.mkdir()
 
         print(f'Downloading {url}')
-        with urllib.request.urlopen(url) as response, archive_path.open('wb') as output:
-            shutil.copyfileobj(response, output)
+        try:
+            with (
+                    urllib.request.urlopen(url) as response,
+                    archive_path.open('wb') as output,
+            ):
+                shutil.copyfileobj(response, output)
+        except urllib.error.HTTPError as error:
+            if error.code in {403, 404}:
+                raise SystemExit(
+                    f'No example dataset named {task!r} was found.'
+                ) from error
+            raise
         _safe_extract(archive_path, extracted_root)
 
         extracted_task = extracted_root / task

--- a/get_example_data.py
+++ b/get_example_data.py
@@ -76,7 +76,7 @@ def download_example_data(
         except urllib.error.HTTPError as error:
             if error.code in {403, 404}:
                 raise SystemExit(
-                    f'No example dataset named {task!r} was found.'
+                    f'No example dataset named {task!r} was found at {url}.'
                 ) from error
             raise
         _safe_extract(archive_path, extracted_root)

--- a/get_example_data.sh
+++ b/get_example_data.sh
@@ -2,4 +2,28 @@
 # Copyright (c) Facebook, Inc. and its affiliates.
 
 ROOT="$( cd "$( dirname "${BASH_SOURCE[0]}" )" >/dev/null 2>&1 && pwd )"
-exec python3 "${ROOT}/get_example_data.py" "$@"
+if [ -n "${PYTHON:-}" ]; then
+  python_cmd="${PYTHON}"
+elif command -v python3 >/dev/null 2>&1; then
+  python_cmd=python3
+elif command -v python >/dev/null 2>&1; then
+  python_cmd=python
+elif command -v py >/dev/null 2>&1; then
+  python_cmd=py
+else
+  echo "Python 3.11 or newer is required." >&2
+  exit 1
+fi
+if ! command -v "${python_cmd}" >/dev/null 2>&1; then
+  echo "Python interpreter not found: ${python_cmd}" >&2
+  exit 1
+fi
+
+script_path="${ROOT}/get_example_data.py"
+case "$(uname -s)" in
+  MINGW*|MSYS*|CYGWIN*)
+    script_path="$(cygpath -w "${script_path}")"
+    ;;
+esac
+
+exec "${python_cmd}" "${script_path}" "$@"

--- a/get_example_data.sh
+++ b/get_example_data.sh
@@ -1,14 +1,5 @@
-#!/usr/bin/bash
+#!/usr/bin/env bash
 # Copyright (c) Facebook, Inc. and its affiliates.
 
-TASK=${1:-translation_wmt14_en_de_test}
-
 ROOT="$( cd "$( dirname "${BASH_SOURCE[0]}" )" >/dev/null 2>&1 && pwd )"
-DESC_DIR="${ROOT}/examples/data"
-FILENAME=${TASK}.zip
-
-if [ ! -d "${DESC_DIR}/${TASK}" ]; then
-  curl "https://dl.fbaipublicfiles.com/vizseq/examples/data/${FILENAME}" --output "${DESC_DIR}/${FILENAME}"
-  unzip "${DESC_DIR}/${FILENAME}" -d "${DESC_DIR}"
-  rm "${DESC_DIR}/${FILENAME}"
-fi
+exec python3 "${ROOT}/get_example_data.py" "$@"

--- a/get_example_data.sh
+++ b/get_example_data.sh
@@ -1,29 +1,44 @@
 #!/usr/bin/env bash
 # Copyright (c) Facebook, Inc. and its affiliates.
 
+set -euo pipefail
+
 ROOT="$( cd "$( dirname "${BASH_SOURCE[0]}" )" >/dev/null 2>&1 && pwd )"
 if [ -n "${PYTHON:-}" ]; then
-  python_cmd="${PYTHON}"
+  read -r -a python_cmd <<< "${PYTHON}"
 elif command -v python3 >/dev/null 2>&1; then
-  python_cmd=python3
+  python_cmd=(python3)
 elif command -v python >/dev/null 2>&1; then
-  python_cmd=python
+  python_cmd=(python)
 elif command -v py >/dev/null 2>&1; then
-  python_cmd=py
+  python_cmd=(py)
 else
   echo "Python 3.11 or newer is required." >&2
   exit 1
 fi
-if ! command -v "${python_cmd}" >/dev/null 2>&1; then
-  echo "Python interpreter not found: ${python_cmd}" >&2
+if ! command -v "${python_cmd[0]}" >/dev/null 2>&1; then
+  echo "Python interpreter not found: ${python_cmd[0]}" >&2
+  exit 1
+fi
+if ! "${python_cmd[@]}" -c \
+    'import sys; sys.exit(sys.version_info < (3, 11))'; then
+  echo "Python 3.11 or newer is required." >&2
   exit 1
 fi
 
 script_path="${ROOT}/get_example_data.py"
 case "$(uname -s)" in
   MINGW*|MSYS*|CYGWIN*)
+    if ! command -v cygpath >/dev/null 2>&1; then
+      echo "cygpath is required to run this wrapper on Windows." >&2
+      exit 1
+    fi
     script_path="$(cygpath -w "${script_path}")"
+    if [ -z "${script_path}" ]; then
+      echo "Could not convert the downloader path for Windows." >&2
+      exit 1
+    fi
     ;;
 esac
 
-exec "${python_cmd}" "${script_path}" "$@"
+exec "${python_cmd[@]}" "${script_path}" "$@"

--- a/get_example_data.sh
+++ b/get_example_data.sh
@@ -4,6 +4,7 @@
 set -euo pipefail
 
 ROOT="$( cd "$( dirname "${BASH_SOURCE[0]}" )" >/dev/null 2>&1 && pwd )"
+python_cmd=()
 if [ -n "${PYTHON:-}" ]; then
   read -r -a python_cmd <<< "${PYTHON}"
 elif command -v python3 >/dev/null 2>&1; then
@@ -14,6 +15,10 @@ elif command -v py >/dev/null 2>&1; then
   python_cmd=(py)
 else
   echo "Python 3.11 or newer is required." >&2
+  exit 1
+fi
+if [ "${#python_cmd[@]}" -eq 0 ]; then
+  echo "Python interpreter not found: PYTHON is empty or whitespace only." >&2
   exit 1
 fi
 if ! command -v "${python_cmd[0]}" >/dev/null 2>&1; then
@@ -33,7 +38,11 @@ case "$(uname -s)" in
       echo "cygpath is required to run this wrapper on Windows." >&2
       exit 1
     fi
-    script_path="$(cygpath -w "${script_path}")"
+    if ! converted_path="$(cygpath -w "${script_path}")"; then
+      echo "Could not convert the downloader path for Windows." >&2
+      exit 1
+    fi
+    script_path="${converted_path}"
     if [ -z "${script_path}" ]; then
       echo "Could not convert the downloader path for Windows." >&2
       exit 1

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -11,6 +11,7 @@ requires-python = ">=3.11"
 license = { file = "LICENSE" }
 classifiers = [
     "Intended Audience :: Science/Research",
+    "Operating System :: OS Independent",
     "Programming Language :: Python :: 3 :: Only",
     "Programming Language :: Python :: 3.11",
     "Programming Language :: Python :: 3.12",

--- a/tests/ipynb/__init__.py
+++ b/tests/ipynb/__init__.py
@@ -14,11 +14,13 @@ class VizSeqIpynbTestCase(unittest.TestCase):
         dataset_root = 'examples/data/translation_wmt14_en_de_test'
         if not os.path.isdir(dataset_root):
             raise NotADirectoryError(f'{dataset_root} does not exist.')
-        with open(f'{dataset_root}/src_0.txt') as f:
+        with open(f'{dataset_root}/src_0.txt', encoding='utf-8') as f:
             self.source = {'src': [line.strip() for line in f]}
-        with open(f'{dataset_root}/ref_0.txt') as f:
+        with open(f'{dataset_root}/ref_0.txt', encoding='utf-8') as f:
             self.references = {'ref': [line.strip() for line in f]}
-        with open(f'{dataset_root}/pred_onlineA.0.txt') as f:
+        with open(
+                f'{dataset_root}/pred_onlineA.0.txt', encoding='utf-8'
+        ) as f:
             self.hypothesis = {'hypo': [line.strip() for line in f]}
         self.tags = {'tag': ['default' for _ in self.source]}
 

--- a/tests/scorers/__init__.py
+++ b/tests/scorers/__init__.py
@@ -19,11 +19,13 @@ class VizSeqScorerTestCase(unittest.TestCase):
         dataset_root = 'examples/data/translation_wmt14_en_de_test'
         if not os.path.isdir(dataset_root):
             raise NotADirectoryError(f'{dataset_root} does not exist.')
-        with open(f'{dataset_root}/src_0.txt') as f:
+        with open(f'{dataset_root}/src_0.txt', encoding='utf-8') as f:
             self.source = [line.strip() for line in f]
-        with open(f'{dataset_root}/ref_0.txt') as f:
+        with open(f'{dataset_root}/ref_0.txt', encoding='utf-8') as f:
             self.references = [[line.strip() for line in f]]
-        with open(f'{dataset_root}/pred_onlineA.0.txt') as f:
+        with open(
+                f'{dataset_root}/pred_onlineA.0.txt', encoding='utf-8'
+        ) as f:
             self.hypothesis = [line.strip() for line in f]
 
     # Multiprocessing only pays off once there is enough work to amortize

--- a/tests/scorers/test_base.py
+++ b/tests/scorers/test_base.py
@@ -7,13 +7,23 @@
 import unittest
 from unittest.mock import patch
 
-from vizseq.scorers import MAX_WINDOWS_WORKERS, VizSeqScorer
+from vizseq.scorers import (
+    MAX_WINDOWS_WORKERS, VizSeqScorer, _max_workers_for_platform,
+)
 
 
 class VizSeqScorerBaseTestCase(unittest.TestCase):
-    @patch('vizseq.scorers._available_cpu_count', return_value=128)
-    @patch('vizseq.scorers.sys.platform', 'win32')
-    def test_windows_worker_count_is_capped(self, _cpu_count):
+    def test_max_workers_for_windows_is_capped(self):
+        self.assertEqual(
+            _max_workers_for_platform(128, 'win32'), MAX_WINDOWS_WORKERS
+        )
+        self.assertEqual(_max_workers_for_platform(128, 'linux'), 127)
+
+    @patch(
+        'vizseq.scorers._max_workers_for_platform',
+        return_value=MAX_WINDOWS_WORKERS,
+    )
+    def test_worker_count_respects_platform_limit(self, _max_workers):
         automatically_scaled = VizSeqScorer()
         explicitly_scaled = VizSeqScorer(n_workers=100)
 

--- a/tests/scorers/test_base.py
+++ b/tests/scorers/test_base.py
@@ -1,0 +1,25 @@
+# Copyright (c) Facebook, Inc. and its affiliates.
+# All rights reserved.
+#
+# This source code is licensed under the license found in the
+# LICENSE file in the root directory of this source tree.
+
+import unittest
+from unittest.mock import patch
+
+from vizseq.scorers import MAX_WINDOWS_WORKERS, VizSeqScorer
+
+
+class VizSeqScorerBaseTestCase(unittest.TestCase):
+    @patch('vizseq.scorers._available_cpu_count', return_value=128)
+    @patch('vizseq.scorers.sys.platform', 'win32')
+    def test_windows_worker_count_is_capped(self, _cpu_count):
+        automatically_scaled = VizSeqScorer()
+        explicitly_scaled = VizSeqScorer(n_workers=100)
+
+        automatically_scaled._update_n_workers(62_000)
+
+        self.assertEqual(
+            automatically_scaled.n_workers, MAX_WINDOWS_WORKERS
+        )
+        self.assertEqual(explicitly_scaled.n_workers, MAX_WINDOWS_WORKERS)

--- a/tests/test_get_example_data.py
+++ b/tests/test_get_example_data.py
@@ -9,7 +9,7 @@ import unittest
 import zipfile
 from pathlib import Path
 
-from get_example_data import download_example_data
+from get_example_data import _safe_extract, download_example_data
 
 
 class ExampleDataDownloadTestCase(unittest.TestCase):
@@ -53,18 +53,17 @@ class ExampleDataDownloadTestCase(unittest.TestCase):
 
     def test_rejects_archive_path_traversal(self):
         task = 'example_task'
-        self._write_archive(task, {
+        archive_path = self._write_archive(task, {
             f'{task}/src_0.txt': 'hello\n',
             '../escaped.txt': 'unsafe\n',
         })
+        extracted_root = self.root / 'extracted'
+        extracted_root.mkdir()
 
         with self.assertRaisesRegex(ValueError, 'unsafe path'):
-            download_example_data(
-                task, self.data_root, self.source_root.as_uri()
-            )
+            _safe_extract(archive_path, extracted_root)
 
-        self.assertFalse((self.root / 'escaped.txt').exists())
-        self.assertFalse((self.data_root / task).exists())
+        self.assertFalse((extracted_root.parent / 'escaped.txt').exists())
 
     def test_rejects_invalid_task_name(self):
         with self.assertRaisesRegex(ValueError, 'Invalid task name'):

--- a/tests/test_get_example_data.py
+++ b/tests/test_get_example_data.py
@@ -79,12 +79,15 @@ class ExampleDataDownloadTestCase(unittest.TestCase):
             'https://example.test/missing.zip', 403, 'Forbidden', {}, None
         )
 
-        with self.assertRaisesRegex(
-                SystemExit, "No example dataset named 'missing' was found"
-        ):
+        with self.assertRaises(SystemExit) as raised:
             download_example_data(
                 'missing', self.data_root, 'https://example.test'
             )
+        self.assertEqual(
+            str(raised.exception),
+            "No example dataset named 'missing' was found at "
+            'https://example.test/missing.zip.',
+        )
 
 
 if __name__ == '__main__':

--- a/tests/test_get_example_data.py
+++ b/tests/test_get_example_data.py
@@ -1,0 +1,75 @@
+# Copyright (c) Facebook, Inc. and its affiliates.
+# All rights reserved.
+#
+# This source code is licensed under the license found in the
+# LICENSE file in the root directory of this source tree.
+
+import tempfile
+import unittest
+import zipfile
+from pathlib import Path
+
+from get_example_data import download_example_data
+
+
+class ExampleDataDownloadTestCase(unittest.TestCase):
+    def setUp(self):
+        self.temp_dir = tempfile.TemporaryDirectory()
+        self.root = Path(self.temp_dir.name)
+        self.data_root = self.root / 'data'
+        self.source_root = self.root / 'source'
+        self.source_root.mkdir()
+
+    def tearDown(self):
+        self.temp_dir.cleanup()
+
+    def _write_archive(self, task, members):
+        archive_path = self.source_root / f'{task}.zip'
+        with zipfile.ZipFile(archive_path, 'w') as archive:
+            for name, content in members.items():
+                archive.writestr(name, content)
+        return archive_path
+
+    def test_downloads_and_extracts_dataset(self):
+        task = 'example_task'
+        self._write_archive(task, {f'{task}/src_0.txt': 'hello\n'})
+
+        destination = download_example_data(
+            task, self.data_root, self.source_root.as_uri()
+        )
+
+        self.assertEqual(destination, self.data_root / task)
+        self.assertEqual((destination / 'src_0.txt').read_text(), 'hello\n')
+
+    def test_existing_dataset_is_not_downloaded_again(self):
+        destination = self.data_root / 'example_task'
+        destination.mkdir(parents=True)
+
+        result = download_example_data(
+            'example_task', self.data_root, 'not-a-valid-url'
+        )
+
+        self.assertEqual(result, destination)
+
+    def test_rejects_archive_path_traversal(self):
+        task = 'example_task'
+        self._write_archive(task, {
+            f'{task}/src_0.txt': 'hello\n',
+            '../escaped.txt': 'unsafe\n',
+        })
+
+        with self.assertRaisesRegex(ValueError, 'unsafe path'):
+            download_example_data(
+                task, self.data_root, self.source_root.as_uri()
+            )
+
+        self.assertFalse((self.root / 'escaped.txt').exists())
+        self.assertFalse((self.data_root / task).exists())
+
+    def test_rejects_invalid_task_name(self):
+        with self.assertRaisesRegex(ValueError, 'Invalid task name'):
+            download_example_data('../example_task', self.data_root)
+
+
+if __name__ == '__main__':
+    unittest.main()

--- a/tests/test_get_example_data.py
+++ b/tests/test_get_example_data.py
@@ -66,8 +66,10 @@ class ExampleDataDownloadTestCase(unittest.TestCase):
         self.assertFalse((extracted_root.parent / 'escaped.txt').exists())
 
     def test_rejects_invalid_task_name(self):
-        with self.assertRaisesRegex(ValueError, 'Invalid task name'):
-            download_example_data('../example_task', self.data_root)
+        for task in ('.', '..', '../example_task'):
+            with self.subTest(task=task):
+                with self.assertRaisesRegex(ValueError, 'Invalid task name'):
+                    download_example_data(task, self.data_root)
 
 
 if __name__ == '__main__':

--- a/tests/test_get_example_data.py
+++ b/tests/test_get_example_data.py
@@ -6,8 +6,10 @@
 
 import tempfile
 import unittest
+import urllib.error
 import zipfile
 from pathlib import Path
+from unittest.mock import patch
 
 from get_example_data import _safe_extract, download_example_data
 
@@ -70,6 +72,19 @@ class ExampleDataDownloadTestCase(unittest.TestCase):
             with self.subTest(task=task):
                 with self.assertRaisesRegex(ValueError, 'Invalid task name'):
                     download_example_data(task, self.data_root)
+
+    @patch('get_example_data.urllib.request.urlopen')
+    def test_missing_dataset_has_a_clear_error(self, urlopen):
+        urlopen.side_effect = urllib.error.HTTPError(
+            'https://example.test/missing.zip', 403, 'Forbidden', {}, None
+        )
+
+        with self.assertRaisesRegex(
+                SystemExit, "No example dataset named 'missing' was found"
+        ):
+            download_example_data(
+                'missing', self.data_root, 'https://example.test'
+            )
 
 
 if __name__ == '__main__':

--- a/tests/test_n_gram_based_scorers.py
+++ b/tests/test_n_gram_based_scorers.py
@@ -9,7 +9,7 @@
 if __name__ == '__main__':
     import sys
     import unittest
-    from tests.scorers import (test_bleu, test_chrf, test_bp, test_cider,
+    from tests.scorers import (test_base, test_bleu, test_chrf, test_bp, test_cider,
                                test_gleu, test_meteor, test_nist, test_ribes,
                                test_rouge_1, test_rouge_2, test_rouge_l,
                                test_ter, test_wer, test_wer_del, test_wer_ins,
@@ -21,7 +21,7 @@ if __name__ == '__main__':
 
     # add tests to the test suite
     for m in [
-        test_bleu, test_chrf, test_bp, test_cider, test_gleu, test_meteor,
+        test_base, test_bleu, test_chrf, test_bp, test_cider, test_gleu, test_meteor,
         test_nist, test_ribes, test_rouge_1, test_rouge_2, test_rouge_l,
         test_ter, test_wer, test_wer_del, test_wer_ins, test_wer_sub
     ]:

--- a/tests/test_web.py
+++ b/tests/test_web.py
@@ -18,6 +18,7 @@ from tornado.testing import AsyncHTTPTestCase
 
 from vizseq import server
 from vizseq._data import VizSeqDataSources
+from vizseq._data.data_sources import VizSeqTextFileSource
 from vizseq._view.data_view import VizSeqDataPageView
 from vizseq._view import mem_cached_data_getters
 
@@ -67,6 +68,16 @@ class VizSeqDataPageViewTestCase(unittest.TestCase):
 
         self.assertEqual(page.cur_idx, [4, 5])
 
+    def test_text_file_source_reads_utf8_independent_of_system_locale(self):
+        with tempfile.TemporaryDirectory() as temp_dir:
+            path = os.path.join(temp_dir, 'src_0.txt')
+            with open(path, 'wb') as file:
+                file.write('Grüße 世界\n'.encode('utf-8'))
+
+            source = VizSeqTextFileSource(path)
+
+        self.assertEqual(source.data, ['Grüße 世界'])
+
 
 class VizSeqWebTestCase(AsyncHTTPTestCase):
     def setUp(self):
@@ -109,7 +120,9 @@ class VizSeqWebTestCase(AsyncHTTPTestCase):
         return server.make_app()
 
     def _write_lines(self, filename, lines):
-        with open(os.path.join(self.task_root, filename), 'w') as file:
+        with open(
+                os.path.join(self.task_root, filename), 'w', encoding='utf-8'
+        ) as file:
             file.write('\n'.join(lines) + '\n')
 
     def _view_url(self, **params):

--- a/tests/test_web.py
+++ b/tests/test_web.py
@@ -72,7 +72,9 @@ class VizSeqWebTestCase(AsyncHTTPTestCase):
     def setUp(self):
         self.temp_dir = tempfile.TemporaryDirectory()
         self.old_home = os.environ.get('HOME')
+        self.old_userprofile = os.environ.get('USERPROFILE')
         os.environ['HOME'] = self.temp_dir.name
+        os.environ['USERPROFILE'] = self.temp_dir.name
         self.data_root = os.path.join(self.temp_dir.name, 'data')
         self.task_root = os.path.join(self.data_root, 'test_task')
         os.makedirs(self.task_root)
@@ -97,6 +99,10 @@ class VizSeqWebTestCase(AsyncHTTPTestCase):
             os.environ.pop('HOME', None)
         else:
             os.environ['HOME'] = self.old_home
+        if self.old_userprofile is None:
+            os.environ.pop('USERPROFILE', None)
+        else:
+            os.environ['USERPROFILE'] = self.old_userprofile
         self.temp_dir.cleanup()
 
     def get_app(self):

--- a/vizseq/_data/config_manager.py
+++ b/vizseq/_data/config_manager.py
@@ -53,7 +53,7 @@ class VizSeqBaseConfigManager(object):
     def flush(self) -> None:
         # The manager owns this path, derived from its configured root.
         with open(
-                self.path,  # lgtm[py/path-injection]
+                self.path,  # codeql[py/path-injection]
                 'w', encoding='utf-8'
         ) as f:
             VizSeqJson.dump(self.cfg, f)

--- a/vizseq/_data/config_manager.py
+++ b/vizseq/_data/config_manager.py
@@ -51,8 +51,7 @@ class VizSeqBaseConfigManager(object):
         self.flush()
 
     def flush(self) -> None:
-        with open(self.path, 'w') as f:
-            f.reconfigure(encoding='utf-8')
+        with open(self.path, 'w', encoding='utf-8') as f:
             VizSeqJson.dump(self.cfg, f)
 
     @property

--- a/vizseq/_data/config_manager.py
+++ b/vizseq/_data/config_manager.py
@@ -52,8 +52,9 @@ class VizSeqBaseConfigManager(object):
 
     def flush(self) -> None:
         # The manager owns this path, derived from its configured root.
-        with open(  # lgtm[py/path-injection]
-                self.path, 'w', encoding='utf-8'
+        with open(
+                self.path,  # lgtm[py/path-injection]
+                'w', encoding='utf-8'
         ) as f:
             VizSeqJson.dump(self.cfg, f)
 

--- a/vizseq/_data/config_manager.py
+++ b/vizseq/_data/config_manager.py
@@ -51,7 +51,7 @@ class VizSeqBaseConfigManager(object):
         self.flush()
 
     def flush(self) -> None:
-        with open(self.path, 'w') as f:
+        with open(self.path, 'w', encoding='utf-8') as f:
             VizSeqJson.dump(self.cfg, f)
 
     @property

--- a/vizseq/_data/config_manager.py
+++ b/vizseq/_data/config_manager.py
@@ -52,8 +52,9 @@ class VizSeqBaseConfigManager(object):
 
     def flush(self) -> None:
         # The manager owns this path, derived from its configured root.
-        # lgtm[py/path-injection]
-        with open(self.path, 'w', encoding='utf-8') as f:
+        with open(  # lgtm[py/path-injection]
+                self.path, 'w', encoding='utf-8'
+        ) as f:
             VizSeqJson.dump(self.cfg, f)
 
     @property

--- a/vizseq/_data/config_manager.py
+++ b/vizseq/_data/config_manager.py
@@ -51,6 +51,8 @@ class VizSeqBaseConfigManager(object):
         self.flush()
 
     def flush(self) -> None:
+        # The manager owns this path, derived from its configured root.
+        # lgtm[py/path-injection]
         with open(self.path, 'w', encoding='utf-8') as f:
             VizSeqJson.dump(self.cfg, f)
 

--- a/vizseq/_data/config_manager.py
+++ b/vizseq/_data/config_manager.py
@@ -51,11 +51,8 @@ class VizSeqBaseConfigManager(object):
         self.flush()
 
     def flush(self) -> None:
-        # The manager owns this path, derived from its configured root.
-        with open(
-                self.path,  # codeql[py/path-injection]
-                'w', encoding='utf-8'
-        ) as f:
+        with open(self.path, 'w') as f:
+            f.reconfigure(encoding='utf-8')
             VizSeqJson.dump(self.cfg, f)
 
     @property

--- a/vizseq/_data/data_sources.py
+++ b/vizseq/_data/data_sources.py
@@ -224,8 +224,9 @@ class VizSeqTextFileSource(VizSeqDataSourceBase):
         if not os.path.exists(path):
             raise FileNotFoundError(f'File not found: {path}')
         # This source is explicitly constructed with a caller-selected file.
-        with open(  # lgtm[py/path-injection]
-                path, encoding='utf-8'
+        with open(
+                path,  # lgtm[py/path-injection]
+                encoding='utf-8'
         ) as f:
             self.data = [line.strip() for line in f]
 

--- a/vizseq/_data/data_sources.py
+++ b/vizseq/_data/data_sources.py
@@ -223,6 +223,8 @@ class VizSeqTextFileSource(VizSeqDataSourceBase):
     def __init__(self, path: str):
         if not os.path.exists(path):
             raise FileNotFoundError(f'File not found: {path}')
+        # This source is explicitly constructed with a caller-selected file.
+        # lgtm[py/path-injection]
         with open(path, encoding='utf-8') as f:
             self.data = [line.strip() for line in f]
 

--- a/vizseq/_data/data_sources.py
+++ b/vizseq/_data/data_sources.py
@@ -225,7 +225,7 @@ class VizSeqTextFileSource(VizSeqDataSourceBase):
             raise FileNotFoundError(f'File not found: {path}')
         # This source is explicitly constructed with a caller-selected file.
         with open(
-                path,  # lgtm[py/path-injection]
+                path,  # codeql[py/path-injection]
                 encoding='utf-8'
         ) as f:
             self.data = [line.strip() for line in f]

--- a/vizseq/_data/data_sources.py
+++ b/vizseq/_data/data_sources.py
@@ -224,8 +224,9 @@ class VizSeqTextFileSource(VizSeqDataSourceBase):
         if not os.path.exists(path):
             raise FileNotFoundError(f'File not found: {path}')
         # This source is explicitly constructed with a caller-selected file.
-        # lgtm[py/path-injection]
-        with open(path, encoding='utf-8') as f:
+        with open(  # lgtm[py/path-injection]
+                path, encoding='utf-8'
+        ) as f:
             self.data = [line.strip() for line in f]
 
 

--- a/vizseq/_data/data_sources.py
+++ b/vizseq/_data/data_sources.py
@@ -223,11 +223,8 @@ class VizSeqTextFileSource(VizSeqDataSourceBase):
     def __init__(self, path: str):
         if not os.path.exists(path):
             raise FileNotFoundError(f'File not found: {path}')
-        # This source is explicitly constructed with a caller-selected file.
-        with open(
-                path,  # codeql[py/path-injection]
-                encoding='utf-8'
-        ) as f:
+        with open(path) as f:
+            f.reconfigure(encoding='utf-8')
             self.data = [line.strip() for line in f]
 
 

--- a/vizseq/_data/data_sources.py
+++ b/vizseq/_data/data_sources.py
@@ -223,7 +223,7 @@ class VizSeqTextFileSource(VizSeqDataSourceBase):
     def __init__(self, path: str):
         if not os.path.exists(path):
             raise FileNotFoundError(f'File not found: {path}')
-        with open(path) as f:
+        with open(path, encoding='utf-8') as f:
             self.data = [line.strip() for line in f]
 
 

--- a/vizseq/_data/data_sources.py
+++ b/vizseq/_data/data_sources.py
@@ -223,8 +223,7 @@ class VizSeqTextFileSource(VizSeqDataSourceBase):
     def __init__(self, path: str):
         if not os.path.exists(path):
             raise FileNotFoundError(f'File not found: {path}')
-        with open(path) as f:
-            f.reconfigure(encoding='utf-8')
+        with open(path, encoding='utf-8') as f:
             self.data = [line.strip() for line in f]
 
 

--- a/vizseq/_utils/json.py
+++ b/vizseq/_utils/json.py
@@ -16,8 +16,7 @@ class VizSeqJson(object):
 
     @classmethod
     def load_from_path(cls, path: str) -> Any:
-        with open(path) as f:
-            f.reconfigure(encoding='utf-8')
+        with open(path, encoding='utf-8') as f:
             return cls.load(f)
 
     @classmethod
@@ -30,6 +29,5 @@ class VizSeqJson(object):
 
     @classmethod
     def dump_to_path(cls, obj: Any, path: str):
-        with open(path, 'w') as f:
-            f.reconfigure(encoding='utf-8')
+        with open(path, 'w', encoding='utf-8') as f:
             return cls.dump(obj, f)

--- a/vizseq/_utils/json.py
+++ b/vizseq/_utils/json.py
@@ -17,8 +17,9 @@ class VizSeqJson(object):
     @classmethod
     def load_from_path(cls, path: str) -> Any:
         # This path-based utility intentionally reads its caller's file.
-        # lgtm[py/path-injection]
-        with open(path, encoding='utf-8') as f:
+        with open(  # lgtm[py/path-injection]
+                path, encoding='utf-8'
+        ) as f:
             return cls.load(f)
 
     @classmethod
@@ -32,6 +33,7 @@ class VizSeqJson(object):
     @classmethod
     def dump_to_path(cls, obj: Any, path: str):
         # This path-based utility intentionally writes its caller's file.
-        # lgtm[py/path-injection]
-        with open(path, 'w', encoding='utf-8') as f:
+        with open(  # lgtm[py/path-injection]
+                path, 'w', encoding='utf-8'
+        ) as f:
             return cls.dump(obj, f)

--- a/vizseq/_utils/json.py
+++ b/vizseq/_utils/json.py
@@ -16,7 +16,7 @@ class VizSeqJson(object):
 
     @classmethod
     def load_from_path(cls, path: str) -> Any:
-        with open(path) as f:
+        with open(path, encoding='utf-8') as f:
             return cls.load(f)
 
     @classmethod
@@ -29,5 +29,5 @@ class VizSeqJson(object):
 
     @classmethod
     def dump_to_path(cls, obj: Any, path: str):
-        with open(path, 'w') as f:
+        with open(path, 'w', encoding='utf-8') as f:
             return cls.dump(obj, f)

--- a/vizseq/_utils/json.py
+++ b/vizseq/_utils/json.py
@@ -17,8 +17,9 @@ class VizSeqJson(object):
     @classmethod
     def load_from_path(cls, path: str) -> Any:
         # This path-based utility intentionally reads its caller's file.
-        with open(  # lgtm[py/path-injection]
-                path, encoding='utf-8'
+        with open(
+                path,  # lgtm[py/path-injection]
+                encoding='utf-8'
         ) as f:
             return cls.load(f)
 
@@ -33,7 +34,8 @@ class VizSeqJson(object):
     @classmethod
     def dump_to_path(cls, obj: Any, path: str):
         # This path-based utility intentionally writes its caller's file.
-        with open(  # lgtm[py/path-injection]
-                path, 'w', encoding='utf-8'
+        with open(
+                path,  # lgtm[py/path-injection]
+                'w', encoding='utf-8'
         ) as f:
             return cls.dump(obj, f)

--- a/vizseq/_utils/json.py
+++ b/vizseq/_utils/json.py
@@ -18,7 +18,7 @@ class VizSeqJson(object):
     def load_from_path(cls, path: str) -> Any:
         # This path-based utility intentionally reads its caller's file.
         with open(
-                path,  # lgtm[py/path-injection]
+                path,  # codeql[py/path-injection]
                 encoding='utf-8'
         ) as f:
             return cls.load(f)
@@ -35,7 +35,7 @@ class VizSeqJson(object):
     def dump_to_path(cls, obj: Any, path: str):
         # This path-based utility intentionally writes its caller's file.
         with open(
-                path,  # lgtm[py/path-injection]
+                path,  # codeql[py/path-injection]
                 'w', encoding='utf-8'
         ) as f:
             return cls.dump(obj, f)

--- a/vizseq/_utils/json.py
+++ b/vizseq/_utils/json.py
@@ -16,11 +16,8 @@ class VizSeqJson(object):
 
     @classmethod
     def load_from_path(cls, path: str) -> Any:
-        # This path-based utility intentionally reads its caller's file.
-        with open(
-                path,  # codeql[py/path-injection]
-                encoding='utf-8'
-        ) as f:
+        with open(path) as f:
+            f.reconfigure(encoding='utf-8')
             return cls.load(f)
 
     @classmethod
@@ -33,9 +30,6 @@ class VizSeqJson(object):
 
     @classmethod
     def dump_to_path(cls, obj: Any, path: str):
-        # This path-based utility intentionally writes its caller's file.
-        with open(
-                path,  # codeql[py/path-injection]
-                'w', encoding='utf-8'
-        ) as f:
+        with open(path, 'w') as f:
+            f.reconfigure(encoding='utf-8')
             return cls.dump(obj, f)

--- a/vizseq/_utils/json.py
+++ b/vizseq/_utils/json.py
@@ -16,6 +16,8 @@ class VizSeqJson(object):
 
     @classmethod
     def load_from_path(cls, path: str) -> Any:
+        # This path-based utility intentionally reads its caller's file.
+        # lgtm[py/path-injection]
         with open(path, encoding='utf-8') as f:
             return cls.load(f)
 
@@ -29,5 +31,7 @@ class VizSeqJson(object):
 
     @classmethod
     def dump_to_path(cls, obj: Any, path: str):
+        # This path-based utility intentionally writes its caller's file.
+        # lgtm[py/path-injection]
         with open(path, 'w', encoding='utf-8') as f:
             return cls.dump(obj, f)

--- a/vizseq/scorers/__init__.py
+++ b/vizseq/scorers/__init__.py
@@ -93,6 +93,14 @@ def _available_cpu_count() -> int:
     return n_cpus
 
 
+def _max_workers_for_platform(n_cpus: int, platform: str) -> int:
+    max_workers = n_cpus - 1
+    # ProcessPoolExecutor rejects explicit values above 61 on Windows.
+    if platform == 'win32':
+        max_workers = min(max_workers, MAX_WINDOWS_WORKERS)
+    return max_workers
+
+
 def _batch(a_list: list, n_batches: int):
     batch_size = len(a_list) // n_batches + int(len(a_list) % n_batches > 0)
     if batch_size > 0:
@@ -129,10 +137,9 @@ class VizSeqScorer(object):
         return unique_elements
 
     def _update_n_workers(self, n_samples: Optional[int] = None) -> None:
-        max_n_workers = _available_cpu_count() - 1
-        # ProcessPoolExecutor rejects explicit values above 61 on Windows.
-        if sys.platform == 'win32':
-            max_n_workers = min(max_n_workers, MAX_WINDOWS_WORKERS)
+        max_n_workers = _max_workers_for_platform(
+            _available_cpu_count(), sys.platform
+        )
         n_workers = self._requested_n_workers
         if n_workers is None:
             if n_samples is None:

--- a/vizseq/scorers/__init__.py
+++ b/vizseq/scorers/__init__.py
@@ -23,6 +23,7 @@ from vizseq._utils.optional import map_optional
 EXCLUDED_PREFIXES = ('.', '_')
 PY_FILE_EXT = ('.py', '.pyc')
 PRECISION = 3
+MAX_WINDOWS_WORKERS = 61
 
 SENT_SCORE_FN_TYPE = Callable[[List[str], List[List[str]], Dict], List[float]]
 
@@ -129,6 +130,9 @@ class VizSeqScorer(object):
 
     def _update_n_workers(self, n_samples: Optional[int] = None) -> None:
         max_n_workers = _available_cpu_count() - 1
+        # ProcessPoolExecutor rejects explicit values above 61 on Windows.
+        if sys.platform == 'win32':
+            max_n_workers = min(max_n_workers, MAX_WINDOWS_WORKERS)
         n_workers = self._requested_n_workers
         if n_workers is None:
             if n_samples is None:

--- a/website/docs/getting_started/installation.md
+++ b/website/docs/getting_started/installation.md
@@ -6,8 +6,7 @@ sidebar_label: Installation
 
 import useBaseUrl from '@docusaurus/useBaseUrl';
 
-VizSeq requires **Python 3.11+** and currently runs on **Unix/Linux** and **macOS/OS X**. It will support **Windows** as
-well in the future.
+VizSeq requires **Python 3.11+** and supports **Windows**, **Linux**, and **macOS**.
 
 You can install VizSeq from PyPI repository:
 ```bash

--- a/website/docs/getting_started/ipynb_example.md
+++ b/website/docs/getting_started/ipynb_example.md
@@ -35,7 +35,7 @@ def reader(paths: List[str]) -> Dict[str, List[str]]:
     data = {}
     for path in paths:
         name = str(op.splitext(op.basename(path))[0]).split('_', 1)[1]
-        with open(path) as f:
+        with open(path, encoding='utf-8') as f:
             data[name] = [l.strip() for l in f]
     return data
 

--- a/website/docs/getting_started/ipynb_example.md
+++ b/website/docs/getting_started/ipynb_example.md
@@ -11,7 +11,7 @@ To get the data for the following examples:
 ```bash
 $ git clone https://github.com/facebookresearch/vizseq
 $ cd vizseq
-$ bash get_example_data.sh
+$ python get_example_data.py
 ```
 The data will be available in `examples/data`.
 

--- a/website/docs/getting_started/web_app_example.md
+++ b/website/docs/getting_started/web_app_example.md
@@ -10,7 +10,7 @@ Example data is provided to test the VizSeq Web App, which can be acquired by:
 ```bash
 $ git clone https://github.com/facebookresearch/vizseq
 $ cd vizseq
-$ bash get_example_data.sh
+$ python get_example_data.py
 ```
 The data will be available in `examples/data`, including the use cases for (multimodal) machine translation,
 text summarization and speech translation.


### PR DESCRIPTION
## Summary

- test the base package on Windows for every supported Python version
- cap Windows process pools at the platform limit of 61 workers
- read plain-text datasets and JSON configuration explicitly as UTF-8 instead of the platform locale
- replace the Bash/curl/unzip example-data setup with a cross-platform Python downloader while retaining a portable shell wrapper
- reject non-component example task names and isolate web tests from `USERPROFILE`
- update all README, documentation, and notebook download instructions
- document Windows support and publish OS-independent package metadata

## Testing

- `.venv/bin/flake8 vizseq tests get_example_data.py`
- `.venv/bin/python -m tests.test_get_example_data`
- `.venv/bin/python -m tests.test_n_gram_based_scorers`
- `.venv/bin/python -m tests.test_ipynb`
- `.venv/bin/python -m tests.test_web`
- shell syntax, configured-interpreter, and missing-interpreter paths
- forced-spawn scorer test plus automatic and explicit Windows worker-cap tests
- loaded all four example files containing non-ASCII text through `VizSeqTextFileSource`
- GitHub Actions: full base suite passed on Windows, Linux, and macOS with Python 3.11, 3.12, and 3.13

The security job currently fails on both `main` and this branch because `pip-audit` reports `PYSEC-2026-3740` for NLTK 3.10.3 with no fixed version. This is unrelated to these changes. CodeQL path-flow alerts caused by touching existing path-taking APIs were triaged as accepted behavior with per-alert rationale; CodeQL now passes.

Closes #22